### PR TITLE
Create a bootstrap governance document

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,99 +1,20 @@
-# OpenFeature project governance
+# OpenFeature Community
 
 [![Roadmap](https://img.shields.io/static/v1?label=Roadmap&message=public&color=green)](https://github.com/orgs/open-feature/projects/1)
 [![Contributing](https://img.shields.io/static/v1?label=Contributing&message=guide&color=blue)](https://github.com/open-feature/.github/blob/main/CONTRIBUTING.md)
 
-This document describes the bootstrap governance process under which the project will operate
-until the final governance process is identified.
+## Welcome to the OpenFeature community!
 
-> :warning: This is a temporary (aka bootstrap) governance document that
-> is effective until the project is fully established.
-> See [this issue](https://github.com/openfeatureflags/governance/issues/11) for the scope of the full governance document.
+If you are interested to be informed about the project or to contribute, sign-up for news and share your expectations using [this Google Form](https://bit.ly/openfeature-signup). This form collects contact emails and also offers opportunities to share your expectations for the project. We will contact you soon.
 
-## Project manifesto
-
-### Goal
-
-Our goal is to create an open standard for feature flag management to support a robust feature flag ecosystem using cloud native technologies.
-
-### Scope
-
-The scope includes but not limited to:
-
-- An **open standard** that allows adopters and vendors to easily integrate with a spec-compliant feature flag solutions
-- A **vendor-agnostic ecosystem** for users, application developers, SREs, and vendors
-- Unified API and SDK
-- Developer-first, cloud-native reference implementation
-- Extensibility for open source and commercial offerings
-- Adoption by the open source and proprietary projects listed on the [Cloud Native Landscape](https://landscape.cncf.io/)
-
-### Why OpenFeature?
-
-There are many existing solutions, open source or not.
-In the industry there are multiple common issues limiting wide adoption:
-
-- **Many SDKs** doing the same thing, but slightly differently
-- SDKs are generally open source but have no ecosystem
-- **Different APIs** in implementations, hence it is difficult to migrate between them
-- **Limited interoperability** across implementations
-- **Missing integration** with observability tools (e.g. OpenTelemetry)
-
-## CNCF membership
-
-Our goal is to join the [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io/) as a sandbox project shortly after the inception of OpenFeature.
-Should it be accepted, the project will establish governance along with the CNCF best practices, 
-and then target reaching the incubating and graduated statuses in the foundation.
-
-### Project Differentiators
-
-This project is more than just copy and paste of existing solutions
-
-* Current solutions often have **eval logic in SDKs**.
-  This may require **updating all your apps** for a new rule type.
-* Config in Feature Flagging tools that are **separate from the rest of the app** make it harder to use approaches like GitOps. 
-* Config and rule changes are **hard to integrate into observability** tools 
-* Information to decide on features already available in observability tools is **not leveraged and collected twice**
-* No standardized format for defining feature flagging rules
+Also feel free to add yourself and/or your organization to [Interested Parties](./interested-parties.md). This is a public listing for those individual and company contributors who declared their interest in the project.
 
 ## Roadmap
 
-The project roadmap is available [here](https://github.com/orgs/openfeatureflags/projects/1).
+The project roadmap is available [here](https://github.com/orgs/open-feature/projects/1).
 New initiatives for the roadmap can be suggested via marking an issue as `roadmap-proposal` and then reaching a community decision as documented in _Decision Making_.
 
-- [Pending roadmap suggestions](https://github.com/search?q=org%3Aopenfeatureflags+label%3Aroadmap-proposal&type=issues)
-
-## Governing Committee
-
-In March 2022 _Project Maintainers_ will assign seven individuals to be members of the _Bootstrap Governing Committee_.
-This is a **temporary** arrangement that should be replaced by an elected governing body before March 2024. 
-At least 3 governing board members should be elected by March 2023.
-
-The _Bootstrap Governing Committee_ is responsible for
-representing the project, 
-making a final decision if a consensus cannot be reached (see _Decision Making_),
-handling the Code of Conduct escalations,
-defining and approving with the project members the final governance model,
-and organizing elections for the elected governance board body.
-
-## Decision making
-
-Decisions are made by a consensus of _Project Members_ and [Interested Parties](./interested-parties.md).
-If this consensus cannot be reached,
-the decision can be made by the plain majority vote of _Bootstrap Governing Committee Members_.
-
-<!-- TODO: List founding members or delegate the decision to CDF TAG App Delivery or another entity -->
-
-Key discussions and decisions should happen asynchronously in communication channels like GitHub Issues, discussions or pull requests.
-Technical decisions are expected to be documented in the
-[OpenFeature Specification](https://github.com/openfeatureflags/spec).
-The community decisions should be documented in this Governance repository.
-
-## Meetings
-
-The project conducts [regular project meetings](https://openfeatureflags.github.io/home/participate/#project-meetings) 
-hosted by its maintainers and contributors.
-These meetings are used as additional discussion and consensus building
-but not for making decisions without prior discussion in async channels.
+- [Pending roadmap suggestions](https://github.com/search?q=org%3Aopen-feature+label%3Aroadmap-proposal&type=issues)
 
 ## Contributing
 
@@ -107,58 +28,6 @@ At the moment the project does not define a
 Contributor License Agreement or 
 [Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco).
 By submitting pull requests submitters acknowledge they grant the [Apache License v2](./LICENSE) to the code and that they are eligible to grant this license for all commits submitted in their pull requests.
-
-### Project roles
-
-The following project roles are defined at the moment:
-_Project member_,
-_Maintainer_,
-_Bootstrap Governance Committee Member_.
-These roles are defined below.
-
-#### Project members
-
-Project members are a group of contributors with the minimum entry bar.
-They are welcome to take leadership in initiatives
-and to participate in the project's open governance and decision making process.
-
-While the project is in the bootstrap governance phase,
-any individual who declares their interest in the [Interested Parties list](./interested-parties.md) will considered as project member and invited to the project's GitHub organization.
-It may require signing a Contributor License Agreement should it be introduced in the project.
-
-#### Maintainers
-
-Maintainers take responsibility for maintaining OpenFeature projects and repositories.
-They review and integrate changes submitted to their repositories,
-and also ensure that the decision making process is followed.
-Maintainer status can be granted within a single repository or within the entire GitHub organization.
-
-Maintainers are elected by project members according to the _Decision Making_ process.
-They are expected to demonstrate substantial code or non-code contributions to the project,
-and to also be able to dedicate some time to maintenance and regular participation in the community.
-
-In addition to the elected maintainer roles,
-3 individuals get the maintainer status at the inception of the project:
-
-- Michael Beemer, @beeme1mr, Dynatrace
-- Alois Reitbauer, @AloisReitbauer, Dynatrace/CNCF/Keptn
-- Oleg Nenashev, @oleg-nenashev, Dynatrace/CDF/Jenkins/Keptn
-
-#### Bootstrap Governance Committee Members
-
-> :warning: This is a **temporary role** while the bootstrap governance is active.
-In the future this role will be replaced by an elected _Governance Committee Member_ role.
-
-Bootstrap Governance Committee members are responsible for representing the project in communications with organizations,
-including but not limited to contributor companies, adopters, vendors and foundations.
-Apart from the representative role,
-they can make a final decision when a consensus cannot be reached.
-
-In March 2022 this role will be assigned by project maintainers to **seven** individuals listed in [Interested Parties](./interested-parties.md).
-Each company/organization should have less than 50% of the seats,
-and hence an organization can have only up to three seats.
-The project maintainers are also responsible to review their nominations with the community,
-and to do the best effort to address any feedback/concerns.
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -62,11 +62,23 @@ New initiatives for the roadmap can be suggested via marking an issue as `roadma
 
 - [Pending roadmap suggestions](https://github.com/search?q=org%3Aopenfeatureflags+label%3Aroadmap-proposal&type=issues)
 
+## Governing Committee
+
+In March 2022 _Project Maintainers_ will assign seven individuals to be members of the _Bootstrap Governing Committee_.
+This is a **temporary** arrangement that should be replaced by an elected governing body before March 2024. 
+
+The _Bootstrap Governing Committee_ is responsible for
+representing the project, 
+making a final decision if a consensus cannot be reached (see _Decision Making_),
+handling the Code of Conduct escalations,
+defining and approving with the project members the final governance model,
+and organizing elections for the elected governance board body.
+
 ## Decision making
 
-Decisions are made by a consensus of [Interested Parties](./interested-parties.md).
+Decisions are made by a consensus of _Project Members_ and [Interested Parties](./interested-parties.md).
 If this consensus cannot be reached,
-the decision can be made by the plain majority of founding members.
+the decision can be made by the plain majority vote of _Bootstrap Governing Committee Members_.
 
 <!-- TODO: List founding members or delegate the decision to CDF TAG App Delivery or another entity -->
 
@@ -94,6 +106,58 @@ At the moment the project does not define a
 Contributor License Agreement or 
 [Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco).
 By submitting pull requests submitters acknowledge they grant the [Apache License v2](./LICENSE) to the code and that they are eligible to grant this license for all commits submitted in their pull requests.
+
+### Project roles
+
+The following project roles are defined at the moment:
+_Project member_,
+_Maintainer_,
+_Bootstrap Governance Committee Member_.
+These roles are defined below.
+
+#### Project members
+
+Project members are a group of contributors with the minimum entry bar.
+They are welcome to take leadership in initiatives
+and to participate in the project's open governance and decision making process.
+
+While the project is in the bootstrap governance phase,
+any individual who declares their interest in the [Interested Parties list](./interested-parties.md) will considered as project member and invited to the project's GitHub organization.
+It may require signing a Contributor License Agreement should it be introduced in the project.
+
+#### Maintainers
+
+Maintainers take responsibility for maintaining OpenFeature projects and repositories.
+They review and integrate changes submitted to their repositories,
+and also ensure that the decision making process is followed.
+Maintainer status can be granted within a single repository or within the entire GitHub organization.
+
+Maintainers are elected by project members according to the _Decision Making_ process.
+They are expected to demonstrate substantial code or non-code contributions to the project,
+and to also be able to dedicate some time to maintenance and regular participation in the community.
+
+In addition to the elected maintainer roles,
+3 individuals get the maintainer status at the inception of the project:
+
+- Michael Beemer, @beeme1mr, Dynatrace
+- Alois Reitbauer, @AloisReitbauer, Dynatrace/CNCF/Keptn
+- Oleg Nenashev, @oleg-nenashev, Dynatrace/CDF/Jenkins/Keptn
+
+#### Bootstrap Governance Committee Members
+
+> :warning: This is a **temporary role** while the bootstrap governance is active.
+In the future this role will be replaced by an elected _Governance Committee Member_ role.
+
+Bootstrap Governance Committee members are responsible for representing the project in communications with organizations,
+including but not limited to contributor companies, adopters, vendors and foundations.
+Apart from the representative role,
+they can make a final decision when a consensus cannot be reached.
+
+In March 2022 this role will be assigned by project maintainers to **seven** individuals listed in [Interested Parties](./interested-parties.md).
+Each company/organization should have less than 50% of the seats,
+and hence an organization can have only up to three seats.
+The project maintainers are also responsible to review their nominations with the community,
+and to do the best effort to address any feedback/concerns.
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ until the final governance process is identified.
 
 > :warning: This is a temporary (aka bootstrap) governance document that
 > is effective until the project is fully established.
+> See [this issue](https://github.com/openfeatureflags/governance/issues/11) for the scope of the full governance document.
 
 ## Project manifesto
 
@@ -20,10 +21,11 @@ Our goal is to create an open standard for feature flag management to support a 
 The scope includes but not limited to:
 
 - An **open standard** that allows adopters and vendors to easily integrate with a spec-compliant feature flag solutions
-- Creating a **vendor-agnostic ecosystem** supported by the CNCF that provide a seamless experience for developers, SREs, and vendors
+- A **vendor-agnostic ecosystem** for users, application developers, SREs, and vendors
 - Unified API and SDK
 - Developer-first, cloud-native reference implementation
 - Extensibility for open source and commercial offerings
+- Adoption by the open source and proprietary projects listed on the [Cloud Native Landscape](https://landscape.cncf.io/)
 
 ### Why OpenFeature?
 
@@ -54,7 +56,6 @@ This project is more than just copy and paste of existing solutions
 The project roadmap is available [here](https://github.com/orgs/openfeatureflags/projects/1).
 New initiatives for the roadmap can be suggested via marking an issue as `roadmap-proposal` and then reaching a community decision as documented in _Decision Making_.
 
-- [Initiatives on the project roadmap](https://github.com/search?q=org%3Aopenfeatureflags+label%3Aroadmap&type=issues)
 - [Pending roadmap suggestions](https://github.com/search?q=org%3Aopenfeatureflags+label%3Aroadmap-proposal&type=issues)
 
 ## Decision making
@@ -65,7 +66,7 @@ the decision can be made by the plain majority of founding members.
 
 <!-- TODO: List founding members or delegate the decision to CDF TAG App Delivery or another entity -->
 
-Key discussions and decisions should happen asynchronously in communication channels like GitHub Issues, pull requests and project chats.
+Key discussions and decisions should happen asynchronously in communication channels like GitHub Issues, discussions or pull requests.
 Technical decisions are expected to be documented in the
 [OpenFeature Specification](https://github.com/openfeatureflags/spec).
 The community decisions should be documented in this Governance repository.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ New initiatives for the roadmap will be marked as `roadmap-proposal` by a mainta
 
 All contributors are welcome!
 Please see the contributing guidelines
-[here](https://github.com/openfeatureflags/.github/blob/main/CONTRIBUTING.md).
+[here](https://github.com/open-feature/.github/blob/main/CONTRIBUTING.md).
 
 ### Contributing prerequisites (CLA/DCO)
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,12 @@
 
 ## Welcome to the OpenFeature community!
 
-If you are interested to be informed about the project or to contribute, sign-up for news and share your expectations using [this Google Form](https://bit.ly/openfeature-signup). This form collects contact emails and also offers opportunities to share your expectations for the project. We will contact you soon.
-
-Also feel free to add yourself and/or your organization to [Interested Parties](./interested-parties.md). This is a public listing for those individual and company contributors who declared their interest in the project.
+If you are interested to be informed about the project or to contribute, feel free to add yourself and/or your organization to [Interested Parties](./interested-parties.md).
 
 ## Roadmap
 
 The project roadmap is available [here](https://github.com/orgs/open-feature/projects/1).
-New initiatives for the roadmap can be suggested via marking an issue as `roadmap-proposal` and then reaching a community decision as documented in _Decision Making_.
+New initiatives for the roadmap will be marked as `roadmap-proposal` by a maintainer. A community decision will then be made as documented in [Decision Making](./governance-charter.md#decision-making).
 
 - [Pending roadmap suggestions](https://github.com/search?q=org%3Aopen-feature+label%3Aroadmap-proposal&type=issues)
 
@@ -28,6 +26,11 @@ At the moment the project does not define a
 Contributor License Agreement or 
 [Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco).
 By submitting pull requests submitters acknowledge they grant the [Apache License v2](./LICENSE) to the code and that they are eligible to grant this license for all commits submitted in their pull requests.
+
+## Governance
+
+Our goal is to join the [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io/) as a sandbox project shortly after the inception of OpenFeature.
+Should it be accepted, the project will establish governance following CNCF recommended practices. Until then, a temporary governance charter can be found [here](./governance-charter.md).
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -30,15 +30,19 @@ The scope includes but not limited to:
 ### Why OpenFeature?
 
 There are many existing solutions, open source or not.
-Unfortunately, they lack key features needed for wide adoption
-by companies and in the open source ecosystem:
+In the industry there are multiple common issues limiting wide adoption:
 
 - **Many SDKs** doing the same thing, but slightly differently
-- Many companies **"rebuilding the wheel"**
 - SDKs are generally open source but have no ecosystem
-- **Vendor lock-in** at code-level
-- **No collaboration** across vendors 
+- **Different APIs** in implementations, hence it is difficult to migrate between them
+- **Limited interoperability** across implentations 
 - **Missing integration** with observability tools (e.g. OpenTelemetry)
+
+## CNCF membership
+
+Our goal is to join the [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io/) as a sandbox project shortly after the inception of OpenFeature.
+Should it be accepted, the project will establish governance along with the CNCF best practices, 
+and then target reaching the incubating and graduated statuses in the foundation.
 
 ### Project Differentiators
 
@@ -49,7 +53,7 @@ This project is more than just copy and paste of existing solutions
 * Config in Feature Flagging tools that are **separate from the rest of the app** make it harder to use approaches like GitOps. 
 * Config and rule changes are **hard to integrate into observability** tools 
 * Information to decide on features already available in observability tools is **not leveraged and collected twice**
-* No **agreed on grammar/structure** for rules which could be automatically validated (e.g. with CUE)
+* No standardized format for defining feature flagging rules
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OpenFeature project governance
 
-[![Roadmap](https://img.shields.io/static/v1?label=Roadmap&message=public&color=green)](https://github.com/orgs/openfeatureflags/projects/1)
-[![Contributing](https://img.shields.io/static/v1?label=Contributing&message=guide&color=blue)](https://github.com/openfeatureflags/.github/blob/main/CONTRIBUTING.md)
+[![Roadmap](https://img.shields.io/static/v1?label=Roadmap&message=public&color=green)](https://github.com/orgs/open-feature/projects/1)
+[![Contributing](https://img.shields.io/static/v1?label=Contributing&message=guide&color=blue)](https://github.com/open-feature/.github/blob/main/CONTRIBUTING.md)
 
 This document describes the bootstrap governance process under which the project will operate
 until the final governance process is identified.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,108 @@
 # OpenFeature project governance
 
-> :warning: Details are coming soon!
+[![Roadmap](https://img.shields.io/static/v1?label=Roadmap&message=public&color=green)](https://github.com/orgs/openfeatureflags/projects/1)
+[![Contributing](https://img.shields.io/static/v1?label=Contributing&message=guide&color=blue)](https://github.com/openfeatureflags/.github/blob/main/CONTRIBUTING.md)
+
+This document describes the bootstrap governance process under which the project will operate
+until the final governance process is identified.
+
+> :warning: This is a temporary (aka bootstrap) governance document that
+> is effective until the project is fully established.
+> A final process 
+
+## Project manifesto
+
+### Our goal
+
+Our goal is to create an open standard for feature flag management to support a robust feature flag ecosystem using cloud native technologies.
+
+### Scope
+
+The scope includes but not limited to:
+
+- An **open standard** that allows adopters and vendors to easily integrate with spec-compliant feature flag solutions
+- Creating a **vendor-agnostic ecosystem** supported by the CNCF that provide a seamless experience for developers, SREs, and vendors
+- Providing Unified API and SDK;
+- Developer-first, cloud-native reference implementation; 
+- Ensuring extensibility for open source and commercial offerings.
+
+### Why OpenFeature?
+
+There are many existing solutions, open source or not.
+Unfortunately they lack key features needed for wide adoption
+by companies and in the open source ecosystem:
+
+- **Many SDKs** doing the same thing, but slightly differently
+- Many companies **“rebuilding” the wheel**
+- SDKs are generally open source but have no ecosystem
+- **“Vendor” lock-in** at code-level
+- **No collaboration** across vendors. 
+- **Missing integration** with observability tools (e.g. OpenTelemetry)
+
+### Project Differentiators
+
+This project is more than just copy and paste of existing solutions
+
+* Current solutions often have **eval logic in SDKs**.
+  This may require **updating all your apps** for a new rule type.
+* Config in Feature Flagging tools that are **separate from the rest of the app** make it harder to use approaches like GitOps. 
+* Config and rule changes are **hard to integrate into observability** tools 
+* Information to decide on features already available in observability tools is **not leveraged and collected twice**
+* No **agreed on grammar/structure** for rules which could be automatically validated (e.g. with CUE)
+
+## Roadmap
+
+The project roadmap is available [here](https://github.com/orgs/openfeatureflags/projects/1).
+New initiatives for the roadmap can be suggested via marking an issue as `roadmap-proposal` and then reaching a community decision as documented in _Decision Making_.
+
+- [Initiatives on the project roadmap](https://github.com/search?q=org%3Aopenfeatureflags+label%3Aroadmap&type=issues)
+- [Pending roadmap suggestions](https://github.com/search?q=org%3Aopenfeatureflags+label%3Aroadmap-proposal&type=issues)
+
+## Decision making
+
+Decisions are made by a consensus of [Interested Parties](./interested-parties.md).
+If this consensus cannot be reached,
+the decision can be made by the plain majority of founding members.
+
+<!-- TODO: List founding members or delegate the decision to CDF TAG App Delivery or another entity -->
+
+Key discussions and decisions should happen asynchronously in communication channels like GitHub Issues, pull requests and project chats.
+Technical decisions are expected to be documented in the
+[OpenFeature Specification](https://github.com/openfeatureflags/spec).
+The community decisions should be documented in this Governance repository.
+
+## Meetings
+
+The project conducts [regular project meetings](https://openfeatureflags.github.io/home/participate/#project-meetings) 
+hosted by its maintainers and contributors.
+These meetings are used as additional discussion and consensus building
+but not for making decisions without prior discussion in async channels.
+
+## Contributing
+
+All contributors are welcome!
+Please see the contributing guidelines
+[here](https://github.com/openfeatureflags/.github/blob/main/CONTRIBUTING.md).
+
+### Contributing prerequisites (CLA/DCO)
+
+At the moment the project does not define a
+Contributor License Agreement or 
+[Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco).
+By submitting pull requests submitters acknowledge they grant the [Apache License v2](./LICENSE) to the code and that they are eligible to grant this license for all commits submitted in their pull requests.
+
+## Code of Conduct
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation. We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+The project and its community abide by [the Code of Conduct](https://github.com/openfeatureflags/.github/blob/main/CODE_OF_CONDUCT.md).
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, available
+[here](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+
+## License
+
+OpenFeature is an open specification and open source project.
+Unless another license is specified explicitly,
+all contents in this GitHub organization are licensed under [Apache License v2](./LICENSE).
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ New initiatives for the roadmap can be suggested via marking an issue as `roadma
 
 In March 2022 _Project Maintainers_ will assign seven individuals to be members of the _Bootstrap Governing Committee_.
 This is a **temporary** arrangement that should be replaced by an elected governing body before March 2024. 
+At least 3 governing board members should be elected by March 2023.
 
 The _Bootstrap Governing Committee_ is responsible for
 representing the project, 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ In the industry there are multiple common issues limiting wide adoption:
 - **Many SDKs** doing the same thing, but slightly differently
 - SDKs are generally open source but have no ecosystem
 - **Different APIs** in implementations, hence it is difficult to migrate between them
-- **Limited interoperability** across implentations 
+- **Limited interoperability** across implementations
 - **Missing integration** with observability tools (e.g. OpenTelemetry)
 
 ## CNCF membership

--- a/README.md
+++ b/README.md
@@ -8,11 +8,10 @@ until the final governance process is identified.
 
 > :warning: This is a temporary (aka bootstrap) governance document that
 > is effective until the project is fully established.
-> A final process 
 
 ## Project manifesto
 
-### Our goal
+### Goal
 
 Our goal is to create an open standard for feature flag management to support a robust feature flag ecosystem using cloud native technologies.
 
@@ -20,23 +19,23 @@ Our goal is to create an open standard for feature flag management to support a 
 
 The scope includes but not limited to:
 
-- An **open standard** that allows adopters and vendors to easily integrate with spec-compliant feature flag solutions
+- An **open standard** that allows adopters and vendors to easily integrate with a spec-compliant feature flag solutions
 - Creating a **vendor-agnostic ecosystem** supported by the CNCF that provide a seamless experience for developers, SREs, and vendors
-- Providing Unified API and SDK;
-- Developer-first, cloud-native reference implementation; 
-- Ensuring extensibility for open source and commercial offerings.
+- Unified API and SDK
+- Developer-first, cloud-native reference implementation
+- Extensibility for open source and commercial offerings
 
 ### Why OpenFeature?
 
 There are many existing solutions, open source or not.
-Unfortunately they lack key features needed for wide adoption
+Unfortunately, they lack key features needed for wide adoption
 by companies and in the open source ecosystem:
 
 - **Many SDKs** doing the same thing, but slightly differently
-- Many companies **“rebuilding” the wheel**
+- Many companies **"rebuilding the wheel"**
 - SDKs are generally open source but have no ecosystem
-- **“Vendor” lock-in** at code-level
-- **No collaboration** across vendors. 
+- **Vendor lock-in** at code-level
+- **No collaboration** across vendors 
 - **Missing integration** with observability tools (e.g. OpenTelemetry)
 
 ### Project Differentiators

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ and to do the best effort to address any feedback/concerns.
 
 We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation. We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
-The project and its community abide by [the Code of Conduct](https://github.com/openfeatureflags/.github/blob/main/CODE_OF_CONDUCT.md).
+The project and its community abide by [the Code of Conduct](https://github.com/open-feature/.github/blob/main/CODE_OF_CONDUCT.md).
 This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
 version 2.1, available
 [here](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).

--- a/governance-charter.md
+++ b/governance-charter.md
@@ -7,11 +7,6 @@ until the final governance process is identified.
 > is effective until the project is fully established.
 > See [this issue](https://github.com/open-feature/governance/issues/11) for the scope of the full governance document.
 
-## CNCF membership
-
-Our goal is to join the [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io/) as a sandbox project shortly after the inception of OpenFeature.
-Should it be accepted, the project will establish governance along with the CNCF recommended practices.
-
 ## Governing Committee
 
 In March 2022 _Project Maintainers_ will assign seven individuals to be members of the _Bootstrap Governing Committee_.

--- a/governance-charter.md
+++ b/governance-charter.md
@@ -1,0 +1,98 @@
+# OpenFeature Governance Charter
+
+This document describes the bootstrap governance process under which the project will operate
+until the final governance process is identified.
+
+> :warning: This is a temporary (aka bootstrap) governance document that
+> is effective until the project is fully established.
+> See [this issue](https://github.com/open-feature/governance/issues/11) for the scope of the full governance document.
+
+## CNCF membership
+
+Our goal is to join the [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io/) as a sandbox project shortly after the inception of OpenFeature.
+Should it be accepted, the project will establish governance along with the CNCF recommended practices.
+
+## Governing Committee
+
+In March 2022 _Project Maintainers_ will assign seven individuals to be members of the _Bootstrap Governing Committee_.
+This is a **temporary** arrangement that should be replaced by an elected governing body before March 2024. 
+At least 3 governing board members should be elected by March 2023.
+
+The _Bootstrap Governing Committee_ is responsible for
+representing the project, 
+making a final decision if a consensus cannot be reached (see _Decision Making_),
+handling the Code of Conduct escalations,
+defining and approving with the project members the final governance model,
+and organizing elections for the elected governance board body.
+
+## Decision making
+
+Decisions are made by a consensus of _Project Members_ and [Interested Parties](./interested-parties.md).
+If this consensus cannot be reached,
+the decision can be made by the plain majority vote of _Bootstrap Governing Committee Members_.
+
+<!-- TODO: List founding members or delegate the decision to CDF TAG App Delivery or another entity -->
+
+Key discussions and decisions should happen asynchronously in communication channels like GitHub Issues, discussions or pull requests.
+Technical decisions are expected to be documented in the
+[OpenFeature Specification](https://github.com/open-feature/spec).
+The community decisions should be documented in this Governance repository.
+
+## Meetings
+
+The project conducts [regular project meetings](https://open-feature.github.io/home/participate/#project-meetings) 
+hosted by its maintainers and contributors.
+These meetings are used as additional discussion and consensus building
+but not for making decisions without prior discussion in async channels.
+
+### Project roles
+
+The following project roles are defined at the moment:
+_Project member_,
+_Maintainer_,
+_Bootstrap Governance Committee Member_.
+These roles are defined below.
+
+#### Project members
+
+Project members are a group of contributors with the minimum entry bar.
+They are welcome to take leadership in initiatives
+and to participate in the project's open governance and decision making process.
+
+While the project is in the bootstrap governance phase,
+any individual who declares their interest in the [Interested Parties list](./interested-parties.md) will considered as project member and invited to the project's GitHub organization.
+It may require signing a Contributor License Agreement should it be introduced in the project.
+
+#### Maintainers
+
+Maintainers take responsibility for maintaining OpenFeature projects and repositories.
+They review and integrate changes submitted to their repositories,
+and also ensure that the decision making process is followed.
+Maintainer status can be granted within a single repository or within the entire GitHub organization.
+
+Maintainers are elected by project members according to the _Decision Making_ process.
+They are expected to demonstrate substantial code or non-code contributions to the project,
+and to also be able to dedicate some time to maintenance and regular participation in the community.
+
+In addition to the elected maintainer roles,
+3 individuals get the maintainer status at the inception of the project:
+
+- Michael Beemer, @beeme1mr, Dynatrace
+- Alois Reitbauer, @AloisReitbauer, Dynatrace/CNCF/Keptn
+- Oleg Nenashev, @oleg-nenashev, Dynatrace/CDF/Jenkins/Keptn
+
+#### Bootstrap Governance Committee Members
+
+> :warning: This is a **temporary role** while the bootstrap governance is active.
+In the future this role will be replaced by an elected _Governance Committee Member_ role.
+
+Bootstrap Governance Committee members are responsible for representing the project in communications with organizations,
+including but not limited to contributor companies, adopters, vendors and foundations.
+Apart from the representative role,
+they can make a final decision when a consensus cannot be reached.
+
+In March 2022 this role will be assigned by project maintainers to **seven** individuals listed in [Interested Parties](./interested-parties.md).
+Each company/organization should have less than 50% of the seats,
+and hence an organization can have only up to three seats.
+The project maintainers are also responsible to review their nominations with the community,
+and to do the best effort to address any feedback/concerns.


### PR DESCRIPTION
Foundation work for #1. The governance document is based on the OpenTelemetry, Keptn and some bits of Contributor Covenant and TAG App Delivery

Preview: https://github.com/openfeatureflags/governance/tree/governance-docs

Signed-off-by: Oleg Nenashev <o.v.nenashev@gmail.com>