### PR TITLE
Update and clean up governance board structure

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -7,7 +7,6 @@ This is the current Governance Committee, per the Governance Committee Charter, 
 - [Alois Reitbauer](https://github.com/aloisreitbauer), Dynatrace, term: Oct 1st, 2022 - TBD
 - [Ben Rometsch](https://github.com/dabeeeenster), Flagsmith, term: April 28, 2022 - TBD
 - [Justin Abrahms](https://github.com/justinabrahms), eBay, term: April 28, 2022 - TBD
-- [Kevin Chu](https://github.com/kbychu), GitLab, term: April 28, 2022 - TBD
 - [Michael Beemer](https://github.com/beeme1mr), Dynatrace, term: April 28, 2022 - TBD
 - [Pete Hodgson](https://github.com/moredip), Independent, term: April 28, 2022 - TBD
 - [Alex Jones](https://github.com/AlexsJones), Canonical, term: Nev 1, 2022 - TBD

--- a/community-members.md
+++ b/community-members.md
@@ -10,6 +10,7 @@ This is the current Governance Committee, per the Governance Committee Charter, 
 - [Kevin Chu](https://github.com/kbychu), GitLab, term: April 28, 2022 - TBD
 - [Michael Beemer](https://github.com/beeme1mr), Dynatrace, term: April 28, 2022 - TBD
 - [Pete Hodgson](https://github.com/moredip), Independent, term: April 28, 2022 - TBD
+- [Alex Jones](https://github.com/AlexsJones), Canonical, term: Nev 1, 2022 - TBD
 
 currently there is one vacant seat
 

--- a/governance-charter.md
+++ b/governance-charter.md
@@ -16,15 +16,6 @@ handling the Code of Conduct escalations,
 defining and approving with the project members the final governance model,
 and organizing elections for the elected governance board body.
 
-Members of the governing committee:
-
-- [Michael Beemer](https://github.com/beeme1mr), Dynatrace, term: April 28, 2022 - TBD
-- [Ben Rometsch](https://github.com/dabeeeenster), Flagsmith, term: April 28, 2022 - TBD
-- [Justin Abrahms](https://github.com/justinabrahms), eBay, term: April 28, 2022 - TBD
-- [Pete Hodgson](https://github.com/moredip), Independent, term: April 28, 2022 - TBD
-- [Alois Reitbauer](https://github.com/aloisreitbauer), Dynatrace, term: Oct 1st, 2022 - TBD
-- [Alex Jones](https://github.com/AlexsJones), Canonical, term: Oct 26th, 2022 - TBD
-- Vacant
 
 > NOTE:
 > In April 2022 _Project Maintainers_ assigned five seven individuals to be members of the _Bootstrap Governing Committee_.


### PR DESCRIPTION
Signed-off-by: Alois Reitbauer <a.reitbauer@gmail.com>

* Adding Alex to the governance board
* Remove double mention of governance members
* Remove Kevin from governance board

