### PR TITLE
fix: removing the setting of the main branch

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -33,7 +33,6 @@ members:
   - Arhell
   - bacherfl
   - benjiro
-  - caniszczyk
   - cdonnellytx
   - davejohnston
   - DavidPHirsch

--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -33,7 +33,7 @@ members:
   - Arhell
   - bacherfl
   - benjiro
-  - caniszccyk
+  - caniszczyk
   - cdonnellytx
   - davejohnston
   - DavidPHirsch

--- a/tools/peribolosbuilder.go
+++ b/tools/peribolosbuilder.go
@@ -147,10 +147,10 @@ func applyRepoDefaults(cfg *org.Config, repoName string) org.Repo {
 	true := true
 	falsy := false
 
-	if repo.DefaultBranch == nil {
-		defaultBranch := "main"
-		repo.DefaultBranch = &defaultBranch
-	}
+	// if repo.DefaultBranch == nil {
+	// 	defaultBranch := "main"
+	// 	repo.DefaultBranch = &defaultBranch
+	// }
 	if repo.HomePage == nil {
 		homepage := "https://openfeature.dev"
 		repo.HomePage = &homepage


### PR DESCRIPTION
it seems like setting the main branch causes issues with peribolos.
We are getting errors that it can not be set.
