### PR TITLE
chore: move thschue to emeritus

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -80,6 +80,7 @@ teams:
   emeritus:
     members:
       - oleg-nenashev
+      - thschue
 
   admins:
     members: []


### PR DESCRIPTION
Move @thschue to emeritus at his request. This still keeps him in the org, which makes him `@-able`.

@aepfli is there anything else to think about here? He is [already removed from CN-matainers](https://github.com/open-feature/community/pull/185).

@thschue please let me know if you don't want this, or if you'd like to be removed from the membership as well. Thanks for all your help and efforts, and best of luck!