### PR TITLE
Add lukas-reining to org

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -52,6 +52,7 @@ members:
   - kbychu
   - kinyoklion
   - lopitz
+  - lukas-reining
   - markphelps
   - matthewelwell
   - mkorbi


### PR DESCRIPTION
Adds [lukas-reining](https://github.com/lukas-reining) to org, who contributed the JS config-cat provider.