### PR TITLE
chore: add org approvers

### DIFF
--- a/config/open-feature/org/workgroup.yaml
+++ b/config/open-feature/org/workgroup.yaml
@@ -19,6 +19,19 @@ approvers:
   - benjiro
   - kinyoklion
   - weyert
+  - aepfli
+  - bacherfl
+  - benjiro
+  - davejohnston
+  - james-milligan
+  - josecolella
+  - Kavindu-Dodan
+  - kinyoklion
+  - staceypotter
+  - tcarrio
+  - thiyagu06
+  - thomaspoignant
+  - lukas-reining 
 
 maintainers: []
 


### PR DESCRIPTION
Adds a number of people to org approvers who have well-established roles elsewhere.

Note this group controls the following repos (as defined in this file):
  - ofep
  - community
  - community-tooling
  - .github
  - spec

If you don't want to be on this list, please reach out or open a PR.