### PR TITLE
chore: nominate Ryan Lamb and Thomas Poignant to TC

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -22,9 +22,9 @@ currently there is one vacant seat
 
 This is the current Technical Committee, per the Technical Committee Charter, in alphabetical order:
 
-- [Dan O’Brien](https://github.com/InTheCloudDan), LaunchDarkly, term: April 28, 2022 - April 28, 2023
-- [Todd Baert](https://github.com/toddbaert), Dynatrace, term: April 28, 2022 - April 28, 2023
-- [Steve Arch](https://github.com/agentgonzo), CloudBees, term: April 28, 2022 - April 28, 2023
+- [Ryan Lamb](https://github.com/kinyoklion), [LaunchDarkly](https://github.com/launchdarkly)
+- [Thomas Poignant](https://github.com/thomaspoignant), [Adevinta](https://github.com/adevinta)
+- [Todd Baert](https://github.com/toddbaert), [Dynatrace](https://github.com/Dynatrace)
 
 ## Community Management
 

--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -52,7 +52,6 @@ members:
   - justaugustus
   - Kavindu-Dodan
   - kbychu
-  - kinyoklion
   - lopitz
   - lukas-reining
   - markphelps

--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -21,14 +21,15 @@ admins:
   - dabeeeenster
 
   # technical steering committee
-  - agentgonzo
+  - kinyoklion
   - toddbaert
-  - InTheCloudDan
+  - thomaspoignant
 
 # org member settings
 members:
   - aepfli
   - agardnerIT
+  - agentgonzo
   - ajhelsby
   - AnaisUrlichs
   - Arhell
@@ -44,6 +45,7 @@ members:
   - faulkt
   - heckelmann
   - hlipsig
+  - InTheCloudDan
   - jakedoublev
   - james-milligan
   - josecolella
@@ -73,7 +75,6 @@ members:
   - therealmitchconnors
   - thisthat
   - thiyagu06
-  - thomaspoignant
   - thschue
   - tomkerkhove
   - weyert
@@ -97,9 +98,9 @@ teams:
 
   Technical Steering Committee:
     members:
-      - agentgonzo
+      - kinyoklion
       - toddbaert
-      - InTheCloudDan
+      - thomaspoignant
 
   Governance Board:
     members:


### PR DESCRIPTION
This PR nominates @kinyoklion and @thomaspoignant to the TC. They have expressed interest in the role and responsibilities outlined in the [TC charter](https://github.com/open-feature/community/blob/main/tech-committee-charter.md#responsibilities-of-the-technical-committee).

@agentgonzo and @InTheCloudDan have decided to step down. Thanks to both of you for your help with the project!

I've added the existing and prospective TC members, and the GC (the GC has veto power as per the charter). I'll be merging this PR tomorrow unless I hear objections.