### PR TITLE
chore: add lukas-reining to sdk-js approvers

### DIFF
--- a/config/open-feature/sdk-javascript/workgroup.yamls-sdk
+++ b/config/open-feature/sdk-javascript/workgroup.yamls-sdk
@@ -6,6 +6,7 @@ approvers:
   - weyert
   - james-milligan
   - tcarrio
+  - lukas-reining
 
 maintainers:
   - beeme1mr


### PR DESCRIPTION
@lukas-reining has contributed to the spec and related discussions, and implemented multi-client support in the both JS SDKs. Lukas implemented events and init/shutdown in the server-side SDK. He also contributed the config-cat JS provider.

https://github.com/open-feature/js-sdk/pull/429
https://github.com/open-feature/js-sdk/pull/436
https://github.com/open-feature/js-sdk-contrib/commit/495bf690b7d83d429622cfcc554ece2b6fb9a34e

@lukas-reining please approve to show you accept the responsibilities [here](https://github.com/open-feature/community/blob/main/CONTRIBUTOR_LADDER.md#approver) and you'd like to be in the role!