### PR TITLE
chore: add sago2k8 to org

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -81,6 +81,7 @@ members:
   - rgrassian-split
   - rschosser
   - s-sen
+  - sago2k8
   - salaboy
   - skyerus
   - sindhuinti


### PR DESCRIPTION
sago2k8 helped contribute the launchdarkly client provider