### PR TITLE
invite liran2000

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -60,6 +60,7 @@ members:
   - justaugustus
   - Kavindu-Dodan
   - kbychu
+  - liran2000
   - lopitz
   - lukas-reining
   - madhead


### PR DESCRIPTION
@liran2000 has written a blog post about his company's adoption, and contributed the java in-memory provider.

@liran2000 please respond to this PR if you'd like an invite to the org.