### PR TITLE
add sheepduke to the org and Rust SDK

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -86,8 +86,9 @@ members:
   - s-sen
   - sago2k8
   - salaboy
-  - skyerus
+  - sheepduke
   - sindhuinti
+  - skyerus
   - staceypotter
   - tcarrio
   - tegenterter

--- a/config/open-feature/sdk-rust/workgroup.yaml
+++ b/config/open-feature/sdk-rust/workgroup.yaml
@@ -7,5 +7,6 @@ approvers: []
 
 maintainers:
   - AlexsJones
+  - sheepduke
 
 admins: []


### PR DESCRIPTION
## This PR

- adds sheepduke to the org
- adds sheepduke as a Rust maintainer

Signed-off-by: Michael Beemer <beeme1mr@users.noreply.github.com>