### PR TITLE
chore: correct test-harness name

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -264,8 +264,8 @@ repos:
     description: Swift implementation of the OpenFeature SDK for iOS clients
   toc-proposal:
     description: TOC proposal fork
-  test-harness:
-    description: Shared test harness for SDK testing, with Gherkin tests
+  flagd-testbed:
+    description: Shared test harness for flagd SDK testing, with Gherkin tests
   vendor-survey:
     archived: true
     private: true


### PR DESCRIPTION
This repo was renamed (it now only contains flagd-specific stuff).

The automation keeps recreating it with the old name which breaks the redirect.