### PR TITLE
chore: add technicalpickles to org

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -91,6 +91,7 @@ members:
   - skyerus
   - staceypotter
   - tcarrio
+  - technicalpickles
   - tegenterter
   - therealmitchconnors
   - thisthat


### PR DESCRIPTION
@technicalpickles has already contributed a great deal to the Ruby SDK, both in reviews and implementation.

@technicalpickles please respond in this PR if you'd be interested in joining thie org. Also, because the Ruby SDK is still a work in progress, only has a single maintainer, and since you've already contributed substantially, I would be more than happy to make you a https://github.com/open-feature/community/blob/main/CONTRIBUTOR_LADDER.md#maintainer in that repository if you're interested.

Let us know!