### PR TITLE
chore: promote bacherfl, add craigpastro

### DIFF
--- a/config/open-feature/cloud-native/workgroup.yaml
+++ b/config/open-feature/cloud-native/workgroup.yaml
@@ -4,13 +4,15 @@ repos:
   - open-feature-operator
 
 approvers:
-  - thomaspoignant
-  - justinabrahms
-  - thisthat
-  - tcarrio
-  - beeme1mr
-  - odubajDT
   - agardnerIT
+  - beeme1mr
+  - craigpastro
+  - justinabrahms
+  - odubajDT
+  - tcarrio
+  - thisthat
+  - thomaspoignant
+ 
 
 maintainers:
   - AlexsJones

--- a/config/open-feature/cloud-native/workgroup.yaml
+++ b/config/open-feature/cloud-native/workgroup.yaml
@@ -9,12 +9,12 @@ approvers:
   - thisthat
   - tcarrio
   - beeme1mr
-  - bacherfl
   - odubajDT
   - agardnerIT
 
 maintainers:
   - AlexsJones
+  - bacherfl
   - james-milligan
   - toddbaert
   - kavindu-dodan

--- a/config/open-feature/sdk-golang/workgroup.yaml
+++ b/config/open-feature/sdk-golang/workgroup.yaml
@@ -7,12 +7,13 @@ approvers:
   - agentgonzo
 
 maintainers:
-  - davejohnston
   - AlexsJones
-  - Kavindu-Dodan
-  - thomaspoignant
-  - skyerus
+  - bacherfl
+  - davejohnston
   - james-milligan
+  - Kavindu-Dodan
+  - skyerus
+  - thomaspoignant
   - toddbaert
 
 admins: []


### PR DESCRIPTION
@bacherfl has contributed significantly to flagd, OFO, but more recently also the go-contribs (he implemented the in-process flagd provider). He's also done work on the go-sdk. @craigpastro helped design and update the fractional evaluation algorithm, added contextual data to flagd evaluations, and also has fixed some flagd bugs

This PR:

 * promotes @bacherfl to maintainer in cloud-native team
 * adds @bacherfl to maintainer in go-sdk team
 * adds @craigpastro to the cloud-native team as an approver