### PR TITLE
chore: add DBlanchard88 to org

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -44,6 +44,7 @@ members:
   - craigpastro
   - davejohnston
   - DavidPHirsch
+  - DBlanchard88
   - dlopes7
   - dnsmichi
   - dyladan


### PR DESCRIPTION
This contributor recently added some tests: https://github.com/open-feature/java-sdk-contrib/pull/468

@DBlanchard88 please comment on this PR and confirm if you're interested in being part of the OpenFeature org. It comes with no obligation, but it will allow us to `@` you and assign you issues.