### PR TITLE
chore: add sighphyre to org

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -88,6 +88,7 @@ members:
   - sago2k8
   - salaboy
   - sheepduke
+  - sighphyre
   - sindhuinti
   - skyerus
   - staceypotter


### PR DESCRIPTION
@sighphyre comes from the Unleash project and has helped review a few Unleash providers contributed by @liran2000 . They are also configured as "component owners" in the contrib repos in go/java for those providers.

@sighphyre please respond in this PR if you're interested in joining the org. It comes with no obligation. The automation that adds you to reviews in our "contrib" monorepos will not work unless you're an org member though!