### PR TITLE
chore: rename schemas -> flagd-schemas

### DIFF
--- a/config/open-feature/cloud-native/workgroup.yaml
+++ b/config/open-feature/cloud-native/workgroup.yaml
@@ -1,6 +1,6 @@
 repos:
   - flagd
-  - schemas
+  - flagd-schemas
   - open-feature-operator
 
 approvers:

--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -258,9 +258,6 @@ repos:
   rust-sdk:
   rust-sdk-contrib:
     description: Community maintained OpenFeature Providers and Hooks for Rust
-  schemas:
-    description: Schemas and spec files pertaining to OpenFeature
-    homepage: https://buf.build/open-feature/flagd
   spec:
     description: OpenFeature specification
   swift-sdk:
@@ -269,6 +266,9 @@ repos:
     description: TOC proposal fork
   flagd-testbed:
     description: Shared test harness for flagd SDK testing, with Gherkin tests
+  flagd-schemas:
+    description: Schemas and spec files pertaining to flagd
+    homepage: https://buf.build/open-feature/flagd
   vendor-survey:
     archived: true
     private: true


### PR DESCRIPTION
Renames the `schemas` repo to `flagd-schemas` as mentioned in slack.

As of yet, this is all flagd-specific stuff. It's the .proto files and json schemas for flagd. I think we risk come confusion by omitting the flagd name here.

This will not impact any submodule pulls, etc, since Github does redirects etc.