### PR TITLE
chore: add new spec teams

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -26,7 +26,7 @@ admins:
   - thomaspoignant
 
 # org member settings - keep alphabetical
-# add yourself here!
+# add yourself here if you're interested in being an org memeber!
 members:
   - aepfli
   - agardnerIT

--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -26,6 +26,7 @@ admins:
   - thomaspoignant
 
 # org member settings - keep alphabetical
+# add yourself here!
 members:
   - aepfli
   - agardnerIT

--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -26,7 +26,7 @@ admins:
   - thomaspoignant
 
 # org member settings - keep alphabetical
-# add yourself here if you're interested in being an org memeber!
+# add yourself here if you're interested in being an org member!
 members:
   - aepfli
   - agardnerIT

--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -62,6 +62,7 @@ members:
   - jonathannorris
   - josecolella
   - justaugustus
+  - kamil-nowosad
   - Kavindu-Dodan
   - kbychu
   - liran2000
@@ -80,6 +81,7 @@ members:
   - nickybondarenko
   - odubajDT
   - oleg-nenashev
+  - oxddr
   - patricioe
   - rcrowe
   - RealAnna

--- a/config/open-feature/spec-definition/workgroup.yaml
+++ b/config/open-feature/spec-definition/workgroup.yaml
@@ -3,11 +3,11 @@ repos:
 approvers:
 
 maintainers:
-  - thomaspoignant
-  - toddbaert
-  - Kavindu-Dodan
-  - moredip
-  - beeme1mr
+ - thomaspoignant
+ - toddbaert
+ - Kavindu-Dodan
+ - moredip
+ - beeme1mr
  - oxddr
  - kamil-nowosad
  

--- a/config/open-feature/spec-definition/workgroup.yaml
+++ b/config/open-feature/spec-definition/workgroup.yaml
@@ -8,5 +8,7 @@ maintainers:
   - Kavindu-Dodan
   - moredip
   - beeme1mr
-
+ - oxddr
+ - kamil-nowosad
+ 
 admins: []

--- a/config/open-feature/spec-definition/workgroup.yaml
+++ b/config/open-feature/spec-definition/workgroup.yaml
@@ -3,12 +3,12 @@ repos:
 approvers:
 
 maintainers:
- - thomaspoignant
- - toddbaert
- - Kavindu-Dodan
- - moredip
- - beeme1mr
- - oxddr
- - kamil-nowosad
+  - thomaspoignant
+  - toddbaert
+  - Kavindu-Dodan
+  - moredip
+  - beeme1mr
+  - oxddr
+  - kamil-nowosad
  
 admins: []

--- a/config/open-feature/spec-definition/workgroup.yaml
+++ b/config/open-feature/spec-definition/workgroup.yaml
@@ -5,5 +5,6 @@ approvers:
 maintainers:
   - thomaspoignant
   - toddbaert
+  - Kavindu-Dodan
 
 admins: []

--- a/config/open-feature/spec-definition/workgroup.yaml
+++ b/config/open-feature/spec-definition/workgroup.yaml
@@ -6,5 +6,6 @@ maintainers:
   - thomaspoignant
   - toddbaert
   - Kavindu-Dodan
+  - moredip
 
 admins: []

--- a/config/open-feature/spec-definition/workgroup.yaml
+++ b/config/open-feature/spec-definition/workgroup.yaml
@@ -1,0 +1,8 @@
+repos:
+
+approvers:
+
+maintainers:
+  - toddbaert
+
+admins: []

--- a/config/open-feature/spec-definition/workgroup.yaml
+++ b/config/open-feature/spec-definition/workgroup.yaml
@@ -3,6 +3,7 @@ repos:
 approvers:
 
 maintainers:
+  - thomaspoignant
   - toddbaert
 
 admins: []

--- a/config/open-feature/spec-definition/workgroup.yaml
+++ b/config/open-feature/spec-definition/workgroup.yaml
@@ -7,5 +7,6 @@ maintainers:
   - toddbaert
   - Kavindu-Dodan
   - moredip
+  - beeme1mr
 
 admins: []

--- a/config/open-feature/spec-evaluation/workgroup.yaml
+++ b/config/open-feature/spec-evaluation/workgroup.yaml
@@ -7,5 +7,6 @@ maintainers:
   - toddbaert
   - fabriziodemaria
   - Kavindu-Dodan
-
+  - nicklasl
+  
 admins: []

--- a/config/open-feature/spec-evaluation/workgroup.yaml
+++ b/config/open-feature/spec-evaluation/workgroup.yaml
@@ -5,5 +5,6 @@ approvers:
 maintainers:
   - thomaspoignant
   - toddbaert
+  - fabriziodemaria
 
 admins: []

--- a/config/open-feature/spec-evaluation/workgroup.yaml
+++ b/config/open-feature/spec-evaluation/workgroup.yaml
@@ -8,5 +8,7 @@ maintainers:
   - fabriziodemaria
   - Kavindu-Dodan
   - nicklasl
+  - oxddr
+  - kamil-nowosad
   
 admins: []

--- a/config/open-feature/spec-evaluation/workgroup.yaml
+++ b/config/open-feature/spec-evaluation/workgroup.yaml
@@ -6,5 +6,6 @@ maintainers:
   - thomaspoignant
   - toddbaert
   - fabriziodemaria
+  - Kavindu-Dodan
 
 admins: []

--- a/config/open-feature/spec-evaluation/workgroup.yaml
+++ b/config/open-feature/spec-evaluation/workgroup.yaml
@@ -1,0 +1,8 @@
+repos:
+
+approvers:
+
+maintainers:
+  - toddbaert
+
+admins: []

--- a/config/open-feature/spec-evaluation/workgroup.yaml
+++ b/config/open-feature/spec-evaluation/workgroup.yaml
@@ -3,6 +3,7 @@ repos:
 approvers:
 
 maintainers:
+  - thomaspoignant
   - toddbaert
 
 admins: []


### PR DESCRIPTION
Team memberships in OpenFeature are configured through this repo.

In this PR, I've added 2 teams: one related to helping define an evaluation wire protocol, and one for helping to develop a standard flag definition.

If you're interested in joining either team, please add your github username in the associated files (as a maintainer). We'll then assume you're interested in helping to develop these standards, by contributing to discussions, doing PoCs, etc.