### PR TITLE
chore: add vpetrusevici to org

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -102,6 +102,7 @@ members:
   - thschue
   - tomkerkhove
   - vahidlazio
+  - vpetrusevici
   - weyert
 
 teams:


### PR DESCRIPTION
@vpetrusevici recently added a Flagsmith .NET provider: https://github.com/open-feature/dotnet-sdk-contrib/pull/89

@vpetrusevici please confirm so we can automatically add you to PRs involving your provider.