### PR TITLE
chore: add liran2000 and thisthat to Java approvers

### DIFF
--- a/config/open-feature/sdk-java/workgroup.yaml
+++ b/config/open-feature/sdk-java/workgroup.yaml
@@ -6,6 +6,8 @@ approvers:
   - thiyagu06
   - thomaspoignant
   - ajhelsby
+  - thisthat
+  - liran2000
 
 maintainers:
   - justinabrahms


### PR DESCRIPTION
@liran2000 has added numerous providers in [Java](https://github.com/open-feature/java-sdk-contrib/blob/main/.github/component_owners.yml) and [Go](https://github.com/open-feature/go-sdk-contrib/blob/main/.github/component_owners.yml), contributed to various discussions, and blog posts.

@thisthat is an approver in the [cloud-native](https://github.com/orgs/open-feature/teams/cloud-native-approvers) team, has contributed to the [flagd Java provider](https://github.com/open-feature/java-sdk-contrib/blob/main/.github/component_owners.yml) including significant new features and bug fixes, reviewed and contributed to [numerous](https://github.com/open-feature/java-sdk/commit/bad5b0a7f5167d0b57bf502ce86b32b1c538746c) [Java](https://github.com/open-feature/java-sdk/pull/531) [SDK](https://github.com/open-feature/java-sdk/commit/a5c93aca0a718a5760bc346f27fd70b59432d11a) PRs, and contributed to spec discussions.

@liran2000 @thisthat thanks for all your efforts. Please approve this PR to signal your interest.