### PR TITLE
chore: add react-test-app

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -253,6 +253,8 @@ repos:
       python
   ruby-sdk:
     description: Ruby implementation of the OpenFeature SDK
+  react-test-app:
+    description: Small test app for @openfeature/react-sdk development and e2e testing
   ruby-sdk-contrib:
     description: Community contributions for hooks and reference providers in
       Ruby

--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -198,9 +198,6 @@ repos:
     description: .NET implementation of the OpenFeature SDK
   dotnet-sdk-contrib:
     description: OpenFeature Providers and Hooks for .NET
-  feature-operator:
-    archived: true
-    description: OpenFeature Operator for Kubernetes
   flagd:
     description: A feature flag daemon with a Unix philosophy
   go-sdk:

--- a/config/open-feature/sdk-javascript/workgroup.yaml
+++ b/config/open-feature/sdk-javascript/workgroup.yaml
@@ -1,6 +1,7 @@
 repos:
   - js-sdk
   - js-sdk-contrib
+  - react-test-harness
 
 approvers:
   - weyert

--- a/config/open-feature/sdk-javascript/workgroup.yaml
+++ b/config/open-feature/sdk-javascript/workgroup.yaml
@@ -1,7 +1,7 @@
 repos:
   - js-sdk
   - js-sdk-contrib
-  - react-test-harness
+  - react-test-app
 
 approvers:
   - weyert


### PR DESCRIPTION
I'm proposing the addition of a small react-test app repo that we can use to experiment with `@openfeature/react-sdk` features and possibly eventually use for headless e2e test suites.

This PR adds the above, and also deletes `feature-operator`, which was a very old PoC version of the `open-feature-operator`, which was archived and collecting vulns in Snyk.