### PR TITLE
chore: move flagd-testbed to cloud-native team

### DIFF
--- a/config/open-feature/cloud-native/workgroup.yaml
+++ b/config/open-feature/cloud-native/workgroup.yaml
@@ -1,6 +1,7 @@
 repos:
   - flagd
   - flagd-schemas
+  - flagd-testbed
   - open-feature-operator
 
 approvers:

--- a/config/open-feature/utils/workgroup.yaml
+++ b/config/open-feature/utils/workgroup.yaml
@@ -1,9 +1,0 @@
-repos:
-  - flagd-testbed
-
-approvers: []
-
-maintainers:
-  - toddbaert
-
-admins: []


### PR DESCRIPTION
No point in having a group just for this, and it's clearly flagd-related.