### PR TITLE
chore: add Lukas Reining to TC

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -21,6 +21,7 @@ currently there is one vacant seat
 
 This is the current Technical Committee, per the Technical Committee Charter, in alphabetical order:
 
+- [Lukas Reining], [codecentric](https://www.codecentric.de/)
 - [Ryan Lamb](https://github.com/kinyoklion), [LaunchDarkly](https://github.com/launchdarkly)
 - [Thomas Poignant](https://github.com/thomaspoignant), [Adevinta](https://github.com/adevinta)
 - [Todd Baert](https://github.com/toddbaert), [Dynatrace](https://github.com/Dynatrace)

--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -21,6 +21,7 @@ admins:
   - dabeeeenster
 
   # technical steering committee
+  - lukas-reining
   - kinyoklion
   - toddbaert
   - thomaspoignant
@@ -125,6 +126,7 @@ teams:
 
   Technical Steering Committee:
     members:
+      - lukas-reining
       - kinyoklion
       - toddbaert
       - thomaspoignant

--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -69,7 +69,6 @@ members:
   - kbychu
   - liran2000
   - lopitz
-  - lukas-reining
   - madhead
   - markphelps
   - matthewelwell

--- a/config/open-feature/sdk-javascript/workgroup.yaml
+++ b/config/open-feature/sdk-javascript/workgroup.yaml
@@ -7,10 +7,10 @@ approvers:
   - weyert
   - james-milligan
   - tcarrio
-  - lukas-reining
 
 maintainers:
   - beeme1mr
   - toddbaert
+  - lukas-reining
 
 admins: []


### PR DESCRIPTION
## Overview

This PR nominates @lukas-reining to the TC. They have expressed interest in the roles and responsibilities outlined in the [TC charter](https://github.com/open-feature/community/blob/main/tech-committee-charter.md?rgh-link-date=2023-05-11T16%3A45%3A22Z#responsibilities-of-the-technical-committee).

## Contributions

- https://github.com/pulls?q=is%3Apr+is%3Amerged+author%3Alukas-reining+archived%3Afalse+sort%3Aupdated-desc+

## Sponsors

- @beeme1mr from the GC
- @toddbaert from the TC
