### PR TITLE
chore: fabriziodemaria org approver

### DIFF
--- a/config/open-feature/org/workgroup.yaml
+++ b/config/open-feature/org/workgroup.yaml
@@ -8,31 +8,31 @@ repos:
 
 # keep alphabetical
 approvers:
-- AlexsJones
-- AloisReitbauer
-- InTheCloudDan
-- Kavindu-Dodan
-- aepfli
-- agentgonzo
-- bacherfl
-- beeme1mr
-- benjiro
-- dabeeeenster
-- davejohnston
-- fabriziodemaria
-- federicobond
-- james-milligan
-- josecolella
-- justinabrahms
-- kinyoklion
-- lukas-reining
-- moredip
-- staceypotter
-- tcarrio
-- thiyagu06
-- thomaspoignant
-- toddbaert
-- weyert
+  - AlexsJones
+  - AloisReitbauer
+  - InTheCloudDan
+  - Kavindu-Dodan
+  - aepfli
+  - agentgonzo
+  - bacherfl
+  - beeme1mr
+  - benjiro
+  - dabeeeenster
+  - davejohnston
+  - fabriziodemaria
+  - federicobond
+  - james-milligan
+  - josecolella
+  - justinabrahms
+  - kinyoklion
+  - lukas-reining
+  - moredip
+  - staceypotter
+  - tcarrio
+  - thiyagu06
+  - thomaspoignant
+  - toddbaert
+  - weyert
 
 maintainers:
   - DavidPHirsch

--- a/config/open-feature/org/workgroup.yaml
+++ b/config/open-feature/org/workgroup.yaml
@@ -6,6 +6,7 @@ repos:
   - spec
   - toc-proposal
 
+# keep alphabetical
 approvers:
 - AlexsJones
 - AloisReitbauer

--- a/config/open-feature/org/workgroup.yaml
+++ b/config/open-feature/org/workgroup.yaml
@@ -7,32 +7,31 @@ repos:
   - toc-proposal
 
 approvers:
-  - beeme1mr
-  - AloisReitbauer
-  - AlexsJones
-  - moredip
-  - justinabrahms
-  - dabeeeenster
-  - agentgonzo
-  - toddbaert
-  - InTheCloudDan
-  - benjiro
-  - kinyoklion
-  - weyert
-  - aepfli
-  - bacherfl
-  - benjiro
-  - davejohnston
-  - james-milligan
-  - josecolella
-  - Kavindu-Dodan
-  - kinyoklion
-  - staceypotter
-  - tcarrio
-  - thiyagu06
-  - thomaspoignant
-  - lukas-reining
-  - federicobond
+- AlexsJones
+- AloisReitbauer
+- InTheCloudDan
+- Kavindu-Dodan
+- aepfli
+- agentgonzo
+- bacherfl
+- beeme1mr
+- benjiro
+- dabeeeenster
+- davejohnston
+- fabriziodemaria
+- federicobond
+- james-milligan
+- josecolella
+- justinabrahms
+- kinyoklion
+- lukas-reining
+- moredip
+- staceypotter
+- tcarrio
+- thiyagu06
+- thomaspoignant
+- toddbaert
+- weyert
 
 maintainers:
   - DavidPHirsch


### PR DESCRIPTION
This PR:

- adds `fabriziodemaria` as an org approver
- alphabetized org approvers

@fabriziodemaria has contributed to the spec (especially around client) and helped implement a few SDKs.

@fabriziodemaria please let us know if you're interested!

Note @benjiro and @kinyoklion were duped in this list previously.