### PR TITLE
chore: add askpt to org

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -37,6 +37,7 @@ members:
   - AnaisUrlichs
   - Arhell
   - ARobertsCollibra
+  - askpt
   - bacherfl
   - benjiro
   - Billlynch


### PR DESCRIPTION
@askpt has helped with numerous .NET issues. He:

- removed the Moq lib: ([here](https://github.com/open-feature/dotnet-sdk/commit/311987f0ed803b83f7cc1791ccc91129a3234a11) and [here](https://github.com/open-feature/dotnet-sdk/commit/e9858d9d66ad75ff13f6becc311c50d8dd75caa3))
- added the readme to the nuget package [here](https://github.com/open-feature/dotnet-sdk/pull/164).
- [deprecated the OTel hook](https://github.com/open-feature/dotnet-sdk-contrib/commit/755c54960bccac97f6836ea8371d75bc2f1a02bb), and [implemented the metrics hook.](https://github.com/open-feature/dotnet-sdk-contrib/pull/114)

@askpt please comment-on or :+1: this PR to signal your interest!