### PR TITLE
chore: add laliconfigcat and luizbon to org

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -70,8 +70,10 @@ members:
   - kamil-nowosad
   - Kavindu-Dodan
   - kbychu
+  - laliconfigcat
   - liran2000
   - lopitz
+  - luizbon
   - luizgribeiro
   - madhead
   - markphelps


### PR DESCRIPTION
@laliconfigcat and @luizbon worked together on the dotnet configcat provider.

@laliconfigcat and @luizbon please react with a :+1: or a comment to this PR to confirm your interest. Being an org member has no obligations, but it allows us to ping you on issues, questions, etc.