### PR TITLE
chore: add znonthedev

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -114,6 +114,7 @@ members:
   - vahidlazio
   - vpetrusevici
   - weyert
+  - znonthedev
 
 teams:
   emeritus:


### PR DESCRIPTION
@znonthedev recently made changes to update the js-sdk e2e tests to use the in-memory provider: https://github.com/open-feature/js-sdk/pull/740