### PR TITLE
chore: Add gruebel as a member

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -57,6 +57,7 @@ members:
   - faulkt
   - federicobond
   - gagantrivedi
+  - gruebel
   - heckelmann
   - hlipsig
   - InTheCloudDan


### PR DESCRIPTION
@gruebel has recently started contributing to the Python SDK. I would like to nominate @gruebel as a member org.

Some recent contributions include:

- https://github.com/open-feature/python-sdk/pull/256
- https://github.com/open-feature/python-sdk/pull/255
- https://github.com/open-feature/python-sdk/pull/254
- https://github.com/open-feature/python-sdk/pull/253

@gruebel please comment on or 👍 this PR to signal your interest!