### PR TITLE
chore: add austindrenski to org

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -38,6 +38,7 @@ members:
   - Arhell
   - ARobertsCollibra
   - askpt
+  - austindrenski
   - bacherfl
   - benjiro
   - Billlynch


### PR DESCRIPTION
@austindrenski has made a few recent contributions to .NET ([SDK](https://github.com/open-feature/dotnet-sdk/pull/168) and [contrib](https://github.com/open-feature/dotnet-sdk-contrib/pull/124)).

@austindrenski, please :+1: this PR or comment to signal your interest. Membership carries no responsibilities, but is the first step on the [contributor ladder](https://github.com/open-feature/community/blob/main/CONTRIBUTOR_LADDER.md), and allows us to easily ping you, etc.