### PR TITLE
chore: add ericpattison to org

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -54,6 +54,7 @@ members:
   - dnsmichi
   - dominikhaska
   - dyladan
+  - ericpattison
   - fabriziodemaria
   - faulkt
   - federicobond


### PR DESCRIPTION
@ericpattison [added a provider](https://github.com/open-feature/dotnet-sdk-contrib/pull/129) that uses the underlying Microsoft.FeatureManagement lib.

@ericpattison this comes with no obligation, but allows us to ping you etc, please :+1: this or comment to indicate your interest.