### PR TITLE
chore: elevate permissions for community management for DavidPHirsch …

### DIFF
--- a/config/open-feature/org/workgroup.yaml
+++ b/config/open-feature/org/workgroup.yaml
@@ -7,7 +7,6 @@ repos:
   - toc-proposal
 
 approvers:
-  - DavidPHirsch
   - beeme1mr
   - AloisReitbauer
   - AlexsJones
@@ -34,6 +33,7 @@ approvers:
   - thomaspoignant
   - lukas-reining 
 
-maintainers: []
+maintainers:
+  - DavidPHirsch
 
 admins: []


### PR DESCRIPTION
@DavidPHirsch is driving a lot of community management topics, therefore he needs to have access to the specific repositories to keep them up to date and align them with the recent decisions and events.

closes: #326 
