### PR TITLE
chore: add Olunusib to org

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -91,6 +91,7 @@ members:
   - nikolasleblanc
   - odubajDT
   - oleg-nenashev
+  - Olunusib
   - oxddr
   - patricioe
   - rcrowe


### PR DESCRIPTION
Add @Olunusib to the org.

@Olunusib has done some minor fixes in flagd:

- https://github.com/open-feature/flagd/pull/1126
- https://github.com/open-feature/flagd/pull/1127

But more recently has contributed features as well:

- https://github.com/open-feature/flagd/pull/1146
- https://github.com/open-feature/flagd/issues/1150

@Olunusib please :+1: or comment to confirm.