### PR TITLE
chore: loosen meeting requirement

### DIFF
--- a/CONTRIBUTOR_LADDER.md
+++ b/CONTRIBUTOR_LADDER.md
@@ -105,7 +105,7 @@ meetings, chat rooms, and other discussion forums.
 - Requirements
 
   - Nominated by a maintainer, with no objections from other maintainers.
-  - Consistently attend meetings and interact with issues.
+  - Consistently attend meetings and/or interact with issues.
 
 - Responsibilities and privileges
 

--- a/CONTRIBUTOR_LADDER.md
+++ b/CONTRIBUTOR_LADDER.md
@@ -105,7 +105,7 @@ meetings, chat rooms, and other discussion forums.
 - Requirements
 
   - Nominated by a maintainer, with no objections from other maintainers.
-  - Consistently attend meetings and/or interact with issues.
+  - Consistently contribute in meetings or in issues, PRs or discussions.
 
 - Responsibilities and privileges
 


### PR DESCRIPTION
In a few discussions with contributors, this has been brought up. I don't think consistently attending meetings is NEEDED. Indeed, we have active TC members who don't attend every meeting, which is not surprising considering our global distribution.