### PR TITLE
chore: promote askpt, austindrenski to .NET approver

### DIFF
--- a/config/open-feature/sdk-dotnet/workgroup.yaml
+++ b/config/open-feature/sdk-dotnet/workgroup.yaml
@@ -5,6 +5,8 @@ repos:
 approvers:
   - bacherfl
   - cdonnellytx
+  - askpt
+  - austindrenski
 
 maintainers:
   - beeme1mr


### PR DESCRIPTION
Both @askpt and @austindrenski have made significant contributions to the .NET SDK and contrib. Both have contributed to issues, discussions, and opened fix and feature PRs.

@askpt : 
- https://github.com/open-feature/dotnet-sdk/issues?q=askpt
- https://github.com/open-feature/dotnet-sdk-contrib/issues?q=askpt
- https://github.com/open-feature/dotnet-sdk/pulls?q=is%3Apr+author%3Aaskpt+is%3Aclosed+

@austindrenski 
- https://github.com/open-feature/dotnet-sdk/issues?q=austindrenski
- https://github.com/open-feature/dotnet-sdk-contrib/issues?q=austindrenski
- https://github.com/open-feature/dotnet-sdk/pulls?q=is%3Apr+author%3Aaustindrenski+is%3Aclosed

I am nominating them both for approver. This means they will be granted binding approval (allowing merge) for the dotnet-sdk and dotnet-sdk-contrib. Maintainer-level approval (at least 1) is still required to enable merge.

@askpt @austindrenski please respond or :+1: this PR if you're interested in [the role](https://github.com/open-feature/community/blob/main/CONTRIBUTOR_LADDER.md#approver).