### PR TITLE
chore: promote luizgribeiro to JS approver

### DIFF
--- a/config/open-feature/sdk-javascript/workgroup.yaml
+++ b/config/open-feature/sdk-javascript/workgroup.yaml
@@ -7,6 +7,7 @@ approvers:
   - weyert
   - james-milligan
   - tcarrio
+  - luizgribeiro
 
 maintainers:
   - beeme1mr


### PR DESCRIPTION
@luizgribeiro has contributed to issues, discussions, and opened fix and feature PRs.

- https://github.com/open-feature/js-sdk/issues?q=luizgribeiro
- https://github.com/open-feature/js-sdk-contrib/issues?q=luizgribeiro
- https://github.com/open-feature/js-sdk/pulls?q=is%3Apr+author%3Aluizgribeiro

I am nominating them for approver. This means they will be granted binding approval (allowing merge) for the js-sdk and js-sdk-contrib. Maintainer-level approval (at least 1) is still required to enable merge.

@luizgribeiro please respond or :+1: this PR if you're interested in [the role](https://github.com/open-feature/community/blob/main/CONTRIBUTOR_LADDER.md#approver).