### PR TITLE
chore: promote federicobond

### DIFF
--- a/config/open-feature/org/workgroup.yaml
+++ b/config/open-feature/org/workgroup.yaml
@@ -31,7 +31,8 @@ approvers:
   - tcarrio
   - thiyagu06
   - thomaspoignant
-  - lukas-reining 
+  - lukas-reining
+  - federicobond
 
 maintainers:
   - DavidPHirsch

--- a/config/open-feature/sdk-python/workgroup.yaml
+++ b/config/open-feature/sdk-python/workgroup.yaml
@@ -2,10 +2,10 @@ repos:
   - python-sdk
   - python-sdk-contrib
 
-approvers:
-  - federicobond
+approvers: []
 
 maintainers:
+  - federicobond
   - hlipsig
   - dabeeeenster
   - mschoenlaub


### PR DESCRIPTION
@federicobond has been the largest contributor to our python artifacts in recent months, and has also been involved in high-level spec discussions. They have certainly met the requirements of maintainership in my opinion.

https://github.com/open-feature/python-sdk/graphs/contributors
https://github.com/open-feature/python-sdk-contrib/graphs/contributors

I'm nominating them for maintainer in the python repos, and approver in the "org" group (spec/website/etc).

@federicobond please approve this issue to signal your interest!

