### PR TITLE
chore: add jonathannorris to JS approvers

### DIFF
--- a/config/open-feature/sdk-javascript/workgroup.yaml
+++ b/config/open-feature/sdk-javascript/workgroup.yaml
@@ -8,6 +8,7 @@ approvers:
   - james-milligan
   - tcarrio
   - luizgribeiro
+  - jonathannorris
 
 maintainers:
   - beeme1mr


### PR DESCRIPTION
@jonathannorris a feature flagging SME (co-founder and CTO at [DevCycle](https://devcycle.com/)). He's helped in spec development, regularly attends meetings, reviews PRs, and helped build the DevCycle web/server providers (which are build directly into the DevCycle SDKs).

@jonathannorris please :+1: or comment on this PR to confirm! 