### PR TITLE
chore: add thisthat to approvers

### DIFF
--- a/config/open-feature/sdk-golang/workgroup.yaml
+++ b/config/open-feature/sdk-golang/workgroup.yaml
@@ -5,6 +5,7 @@ repos:
 approvers:
   - beeme1mr
   - agentgonzo
+  - thisthat
 
 maintainers:
   - AlexsJones


### PR DESCRIPTION
@thisthat is already a Java approver. He contributes regularly to spec discussions, and reviews issues in both Java and Go.
Though his contributions in Go SDK are mostly reviews, considering his skills in that language (proven by his many contributions in flagd and OFO) and his Java contributions, I think he'll be able to contribute significantly to the quality of our Go SDK.

2023: https://github.com/thisthat?tab=overview&from=2023-12-01&to=2023-12-31&org=open-feature
2024: https://github.com/thisthat?tab=overview&from=2024-02-01&to=2024-02-06&org=open-feature