### PR TITLE
chore: add maxveldink to org approvers

### DIFF
--- a/config/open-feature/org/workgroup.yaml
+++ b/config/open-feature/org/workgroup.yaml
@@ -26,6 +26,7 @@ approvers:
   - justinabrahms
   - kinyoklion
   - lukas-reining
+  - maxveldink
   - moredip
   - staceypotter
   - tcarrio


### PR DESCRIPTION
[maxveldink](https://github.com/maxveldink) has contributed to spec discussions, attended meetings, and is doing great working [helping with the Ruby SDK implementation](https://github.com/open-feature/ruby-sdk/commits?author=maxveldink).

This allows him approval on spec/website/etc PRs.