### PR TITLE
chore: add nicklasl org approvers

### DIFF
--- a/config/open-feature/org/workgroup.yaml
+++ b/config/open-feature/org/workgroup.yaml
@@ -30,6 +30,7 @@ approvers:
   - lukas-reining
   - maxveldink
   - moredip
+  - nicklasl
   - staceypotter
   - tcarrio
   - thiyagu06


### PR DESCRIPTION
@nicklasl has made significant contributions especially to client SDKs:

https://github.com/open-feature/kotlin-sdk/graphs/contributors
https://github.com/open-feature/swift-sdk/graphs/contributors

They've been involved in spec discussions and attend meetings frequently.

This gives @nicklasl approval in spec/website/etc PRs.

@nicklasl please indicate here if you're interested.