### PR TITLE
chore: make ruby sdk contrib repo public

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -277,9 +277,7 @@ repos:
   react-test-app:
     description: Small test app for @openfeature/react-sdk development and e2e testing
   ruby-sdk-contrib:
-    description: Community contributions for hooks and reference providers in
-      Ruby
-    private: true
+    description: Community contributions for hooks and reference providers in Ruby
   rust-sdk:
   rust-sdk-contrib:
     description: Community maintained OpenFeature Providers and Hooks for Rust


### PR DESCRIPTION
## This PR

- enables public access to the ruby sdk contrib repo

### Notes

Requested on Slack: https://cloud-native.slack.com/archives/C06M49903PV/p1712066177009579