### PR TITLE
chore: add jenshenneberg to the org

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -73,6 +73,7 @@ members:
   - james-milligan
   - jamescarr
   - jarebudev
+  - jenshenneberg 
   - josecolella
   - juanparadox
   - justaugustus


### PR DESCRIPTION
@jenshenneberg has [expressed interest](https://cloud-native.slack.com/archives/C06EDTWU25B/p1713301351138369?thread_ts=1713211358.968929&cid=C06EDTWU25B) in joining the OpenFeature org. Jens has contributed to the .NET SDK and the Statsig Provider.

https://github.com/open-feature/dotnet-sdk-contrib/pulls?q=is%3Apr+author%3Ajenshenneberg

@jenshenneberg  please signal your interest by adding 👍 or approving this PR. After it's merged, you receive an email inviting you.