### PR TITLE
add Andrew MacLean as a community manager

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -27,7 +27,8 @@ This is the current Technical Committee, per the Technical Committee Charter, in
 
 These are community maintainers responsible for cross-functional project communications, events, and other functions as needed.
 
-[David Hirsch](https://github.com/DavidPHirsch) Dynatrace
+- [Andrew MacLean](https://github.com/andrewdmaclean) DevCycle
+- [David Hirsch](https://github.com/DavidPHirsch) Dynatrace
 
 ### Project roles
 

--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -37,6 +37,7 @@ members:
   - ajwootto
   - AlexsJones
   - alina-v1
+  - andrewdmaclean
   - AnaisUrlichs
   - Arhell
   - ARobertsCollibra


### PR DESCRIPTION
## This PR

- adds Andrew to the org
- adds Andrew as an OpenFeature community manager

### Notes

Andrew has been an active member of the OpenFeature community and a great advocate for feature flags. He has tons of experience building and engaging with a community. In this role, Andrew can leverage CNCF resources and work more closely with the OpenFeature technical and governance committee.

Here are some examples of his previous involvment:

- https://twitter.com/andrewdmaclean/status/1777360060525826240
- https://cloud-native.slack.com/archives/C0344AANLA1/p1712076267789559
- https://blog.devcycle.com/how-openfeature-was-the-key-to-escaping-feature-flag-vendor-lockin-a-vuejs-story/

@andrewdmaclean, please signal your interest by adding 👍 or approving this PR. After it's merged, you receive an email inviting you.