### PR TITLE
chore: add Jens as a .NET approver

### DIFF
--- a/config/open-feature/sdk-dotnet/workgroup.yaml
+++ b/config/open-feature/sdk-dotnet/workgroup.yaml
@@ -7,6 +7,7 @@ approvers:
   - cdonnellytx
   - askpt
   - austindrenski
+  - jenshenneberg
 
 maintainers:
   - beeme1mr


### PR DESCRIPTION
## This PR

- adds Jens Kjær Hjenneberg as a .NET approver

### Notes

Jens built the Statsig provider for .NET and has helped with many reviews.