### PR TITLE
chore: add cpitstick-latai to org

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -52,6 +52,7 @@ members:
   - cdonnellytx
   - colebaileygit
   - craigpastro
+  - cpitstick-latai
   - davejohnston
   - DavidPHirsch
   - DBlanchard88


### PR DESCRIPTION
@cpitstick-latai has made numerous suggestions and PRs for OFO: https://github.com/open-feature/open-feature-operator/pulls/cpitstick-latai and is considering running it at their org.

@cpitstick-latai, please thumbs up this PR if you are interested in joining the org. It comes with no obligation, but it's the first step on the [contributor ladder](https://github.com/open-feature/community/blob/main/CONTRIBUTOR_LADDER.md). It will allow us to ping you on issues/PRs.