### PR TITLE
chore: add alexandraoberaigner to org

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -35,6 +35,7 @@ members:
   - agentgonzo
   - ajhelsby
   - ajwootto
+  - alexandraoberaigner
   - AlexsJones
   - alina-v1
   - alxckn


### PR DESCRIPTION
@alexandraoberaigner added a mvnw script to the Java contribs: https://github.com/open-feature/java-sdk-contrib/pull/811

@alexandraoberaigner, please thumbs up this PR if you are interested in joining the org. It comes with no obligation, but it's the first step on the [contributor ladder](https://github.com/open-feature/community/blob/main/CONTRIBUTOR_LADDER.md). It will allow us to ping you on issues/PRs.