### PR TITLE
chore: add anghelflorinm to org

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -41,6 +41,7 @@ members:
   - alxckn
   - andrewdmaclean
   - AnaisUrlichs
+  - anghelflorinm
   - Arhell
   - ARobertsCollibra
   - askpt


### PR DESCRIPTION
@anghelflorinm is from Google and is interested in helping to [define a flag manifest and codegen solution](https://github.com/orgs/open-feature/discussions/383) for OpenFeature.
Florin has created the #openfeature-codegen Slack channel and has started a [project proposal](https://docs.google.com/document/d/19CTHDUZ6J-GLuDGxO_dmycieG99telHV0SX7cJcGAsw/edit?usp=sharing).

@anghelflorinm, please thumbs up this PR if you are interested in joining the org.