### PR TITLE
chore: add djosephsen to org

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -60,6 +60,7 @@ members:
   - DavidPHirsch
   - DBlanchard88
   - dgorton
+  - djosephsen
   - dlopes7
   - dnsmichi
   - dominikhaska


### PR DESCRIPTION
@djosephsen has been helping with flagd features, specifically https://github.com/open-feature/flagd/issues/1344

@djosephsen please approve or :+1: this PR if you are interested. There's no obligation in joining but it means we'll be able to ping you and you will no longer need approvals to run CI jobs.