### PR TITLE
chore: invite ryanprayogo

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -116,6 +116,7 @@ members:
   - RealAnna
   - rgrassian-split
   - rschosser
+  - ryanprayogo
   - s-sen
   - sago2k8
   - salaboy


### PR DESCRIPTION
@ryanprayogo has recently found / fixed a couple [java](https://github.com/open-feature/java-sdk/pull/1057) [bugs](https://github.com/open-feature/java-sdk/pull/1060)!

Thanks @ryanprayogo! This adds you to the OpenFeature org. It comes with no obligation, but allows us to assign/ping you, and it's the first step on the [contributor ladder](https://github.com/open-feature/community/blob/main/CONTRIBUTOR_LADDER.md).

@ryanprayogo Please approve or :+1: this PR to signal you're interested.