### PR TITLE
chore: add UtkarshSharma2612 to org

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -135,6 +135,7 @@ members:
   - thschue
   - tjosepo
   - tomkerkhove
+  - UtkarshSharma2612
   - vahidlazio
   - vpetrusevici
   - znonthedev


### PR DESCRIPTION
@UtkarshSharma2612 recently made a significant enhancement to the flagd-java provider: https://github.com/open-feature/java-sdk-contrib/pull/925

This adds them to the org. 

@UtkarshSharma2612 please :+1:  or approve this PR to signal your interest; there's no obligation but it allows us to ping/add/assign you and it's the first step on the contributor ladder.