### PR TITLE
chore: add pradeepbbl

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -112,6 +112,7 @@ members:
   - Olunusib
   - oxddr
   - patricioe
+  - pradeepbbl
   - rcrowe
   - RealAnna
   - rgrassian-split


### PR DESCRIPTION
@pradeepbbl has been working on some enhancements to flagd providers to support custom name resolvers: https://github.com/open-feature/flagd/pull/1414 

@pradeepbbl when this is merged, it will add you to the org. Being in the org comes with no obligation but allows us to assign you and ping you easier, etc. Please :+1: or approve this PR if you want to join and you will get an email invite.