### PR TITLE
chore: add guidobrei to org

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -71,8 +71,8 @@ members:
   - faulkt
   - federicobond
   - gagantrivedi
-  - guidobrei
   - gruebel
+  - guidobrei
   - hairyhenderson
   - heckelmann
   - hlipsig

--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -71,6 +71,7 @@ members:
   - faulkt
   - federicobond
   - gagantrivedi
+  - guidobrei
   - gruebel
   - hairyhenderson
   - heckelmann


### PR DESCRIPTION
@guidobrei actively contributed to the [java-sdk](https://github.com/open-feature/java-sdk/pulls/guidobrei) and the [java-sdk-contrib](https://github.com/open-feature/java-sdk-contrib/pulls/guidobrei) also helped in[ reviews for multiple prs](https://github.com/search?q=org%3Aopen-feature+guidobrei&type=pullrequests). Hence, I want to propose adding him as a community member.

@guidobrei, please thumbs up this PR if you're interested in joining the organization. There's no obligation to join.
