### PR TITLE
chore: promote aepfli to java maintainer

### DIFF
--- a/config/open-feature/sdk-java/workgroup.yaml
+++ b/config/open-feature/sdk-java/workgroup.yaml
@@ -3,7 +3,6 @@ repos:
   - java-sdk-contrib
 
 approvers:
-  - aepfli
   - thiyagu06
   - thomaspoignant
   - ajhelsby
@@ -11,6 +10,7 @@ approvers:
   - liran2000
 
 maintainers:
+  - aepfli
   - justinabrahms
   - toddbaert
   - agentgonzo


### PR DESCRIPTION
@aepfli has made significant contributions to the OpenFeature Java ecosystem. They have:

- conceived and built our Junit testing extension, allowing simple and consistent testing via annotations: https://github.com/open-feature/java-sdk-contrib/tree/main/tools/junit-openfeature
- have made [numerous](https://github.com/open-feature/java-sdk-contrib/pull/942) [contributions](https://github.com/open-feature/java-sdk-contrib/pull/860) to the [SDK](https://github.com/open-feature/java-sdk/pull/1095) and [flagd](https://github.com/open-feature/java-sdk-contrib/pull/833) provider
- they've been active contributors to the community, representing OpenFeature at conferences and in fact building our community management automation in use in this PR

Full disclosure, @aepfli is a member of my organization (Dynatrace) so I will be nominating them but seeking approval from at least 2 non-Dynatrace maintainers or TC/GC members.

@aepfli please :+1: or approve this yourself as well!