### PR TITLE
chore: switch to LFX Zoom account

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,9 @@ For those who are brand new to OpenFeature and want to chat or get redirected to
 
 | Name | Meeting Time | Meeting Notes | Discussions |
 | ---- | ------------ | ------------- | ----------- |
-| OpenFeature Community Meeting | Every other Thursday at 10:00 am ET | [Google Doc](https://docs.google.com/document/d/1pp6t2giTcdEdVAri_2B1Z6Mv8mHhvtZT1AmkPV9K7xQ/edit?usp=sharing) | [Zoom](https://dynatrace.zoom.us/j/94194023310?pwd=T0xDQ3J5VzlrdFlOTDIvcmtYVkdEdz09) |
+| OpenFeature Community Meeting | Every other Thursday at 10:00 am ET | [Google Doc](https://docs.google.com/document/d/1pp6t2giTcdEdVAri_2B1Z6Mv8mHhvtZT1AmkPV9K7xQ/edit?usp=sharing) | [Zoom](https://zoom-lfx.platform.linuxfoundation.org/meeting/96167755909?password=212f416d-85a3-4f2f-ad15-2d7d4ca43578) |
 
-All upcoming OpenFeature meetings and events are in our [CNCF OpenFeature Community Chapter](https://community.cncf.io/openfeature/) and via public calendars:
-
-- [Web](https://calendar.google.com/calendar/embed?src=0ua7i1hiv5dh18b27toah63644%40group.calendar.google.com)
-- [Google Calendar](https://calendar.google.com/calendar/u/0?cid=MHVhN2kxaGl2NWRoMThiMjd0b2FoNjM2NDRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ)
-- [iCal](https://calendar.google.com/calendar/ical/0ua7i1hiv5dh18b27toah63644%40group.calendar.google.com/public/basic.ics)
+All upcoming OpenFeature meetings and events are on our [public calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/openfeature?view=week).
 
 ### Social Media
 


### PR DESCRIPTION
## This PR

- switch the LFX Zoom account
- updates link to the LFX public calendar

### Notes

This is the initial PR to switch to a Zoom account owned by the Linux Foundation.

### Follow-up Tasks

- [ ] Update references in other repos
- [ ] Update the the Slack bot reminder message
- [ ] Manually send a reminder early next week
- [ ] Update links in the meeting notes
- [ ] Update the CNCF community page with updated links
