### PR TITLE
chore: add alemrtv

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -37,6 +37,7 @@ members:
   - agentgonzo
   - ajhelsby
   - ajwootto
+  - alemrtv
   - alexandraoberaigner
   - AlexsJones
   - alina-v1


### PR DESCRIPTION
@alemrtv recently added [significant functionality](https://github.com/open-feature/flagd/pull/1448) to flagd (a new command line argument to add arbitrary static context values to all evaluations)

@alemrtv this PR adds you to the OpenFeature org. Being an org member comes with no obligation at all, but it allows you to run actions on PRs and makes it easier for us to ping you. It's the first step on the [contributor ladder](https://github.com/open-feature/community/blob/main/CONTRIBUTOR_LADDER.md).

If you approve or :+1: this PR, we will merge it and you will receive an org invite in your email.
