### PR TITLE
chore: add arttonoyan

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -47,6 +47,7 @@ members:
   - anghelflorinm
   - Arhell
   - ARobertsCollibra
+  - arttonoyan
   - askpt
   - austindrenski
   - bacherfl


### PR DESCRIPTION
@arttonoyan has added the DI features to the dotnet SDK:

- https://github.com/open-feature/dotnet-sdk/pull/310
- https://github.com/open-feature/dotnet-sdk/pull/324

@arttonoyan this adds you to the org. This comes with no obligation but allows us to ping you and add you to PRs easier and is the first step on the [contributor ladder](https://github.com/open-feature/community/blob/main/CONTRIBUTOR_LADDER.md).

If you're interested, please :+1: or approve this PR and when merged you will get an invite to the org in your email.