### PR TITLE
chore: add cupofcat

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -60,6 +60,7 @@ members:
   - colebaileygit
   - craigpastro
   - cpitstick-latai
+  - cupofcat
   - davejohnston
   - DavidPHirsch
   - DBlanchard88


### PR DESCRIPTION
@cupofcat has been working on flagd and flagd providers:

- https://github.com/open-feature/go-sdk-contrib/pull/598
- https://github.com/open-feature/flagd/issues/1481
- https://github.com/open-feature/flagd/issues/1487

@cupofcat this PR adds you to the OpenFeature org. If you approve or :+1: , we will merge it and you will get an invite. Being in the org comes with no obligation but allows us to contact you more easily and it's the first step on the [contributor ladder](https://github.com/open-feature/community/blob/main/CONTRIBUTOR_LADDER.md).