### PR TITLE
chore: add Maxim to org

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -102,6 +102,7 @@ members:
   - madhead
   - markphelps
   - matthewelwell
+  - MaximFischuk
   - maxveldink
   - mfranberg
   - mihirm21


### PR DESCRIPTION
@MaximFischukhas been working on the Rust SDK:

- https://github.com/open-feature/rust-sdk/pull/95

@MaximFischuk this PR adds you to the OpenFeature org. If you approve or 👍 , we will merge it and you will get an invite. Being in the org comes with no obligation but allows us to contact you more easily and it's the first step on the [contributor ladder](https://github.com/open-feature/community/blob/main/CONTRIBUTOR_LADDER.md).