### PR TITLE
chore: add Jose to org

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -86,6 +86,7 @@ members:
   - james-milligan
   - jamescarr
   - jarebudev
+  - jbovet
   - jenshenneberg 
   - josecolella
   - juanparadox


### PR DESCRIPTION
@jbovetbeen working on the Rust SDK and doc improvements:

- https://github.com/open-feature/rust-sdk/pull/95 (Reviewer)
- https://github.com/open-feature/openfeature.dev/commits?author=jbovet&since=2024-05-01&until=2024-06-01

@jbovet this PR adds you to the OpenFeature org. If you approve or 👍 , we will merge it and you will get an invite. Being in the org comes with no obligation but allows us to contact you more easily and it's the first step on the [contributor ladder](https://github.com/open-feature/community/blob/main/CONTRIBUTOR_LADDER.md).