### PR TITLE
chore: add askpt as a .NET maintainer

### DIFF
--- a/config/open-feature/sdk-dotnet/workgroup.yaml
+++ b/config/open-feature/sdk-dotnet/workgroup.yaml
@@ -5,7 +5,6 @@ repos:
 approvers:
   - bacherfl
   - cdonnellytx
-  - askpt
   - austindrenski
   - jenshenneberg
 
@@ -14,5 +13,6 @@ maintainers:
   - toddbaert
   - benjiro
   - kinyoklion
+  - askpt
 
 admins: []


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

* Removed `askpt` from the `approvers` list.
* Added `askpt` to the `maintainers` list.

### Notes
I have been actively maintaining the dotnet-sdk for the last couple of months. 