### PR TITLE
chore: add chrfwow to Java approvers

### DIFF
--- a/config/open-feature/sdk-java/workgroup.yaml
+++ b/config/open-feature/sdk-java/workgroup.yaml
@@ -8,6 +8,7 @@ approvers:
   - ajhelsby
   - thisthat
   - liran2000
+  - chrfwow
 
 maintainers:
   - aepfli


### PR DESCRIPTION
@chrfwow has been contributing significantly to our Java implementations:

- finally hook change in SDK: https://github.com/open-feature/java-sdk/pull/1262
- flag metadata support in the flagd java provider: https://github.com/open-feature/java-sdk-contrib/pull/1122

And most recently identified a deadlock in the Java SDK, opened an issue describing it, and has been helping to guide the fix by a new contributor: https://github.com/open-feature/java-sdk/pull/1314

I'm nominating them for Java approver. @chrfwow please approve or :+1: this PR for signal your interest. For transparency, @chrfwow works at my company. I will require at least one green approval from a contributor from elsewhere.