### PR TITLE
chore/add tiagoapolo

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -88,7 +88,7 @@ members:
   - jamescarr
   - jarebudev
   - jbovet
-  - jenshenneberg 
+  - jenshenneberg
   - josecolella
   - juanparadox
   - justaugustus
@@ -142,6 +142,7 @@ members:
   - thisthat
   - thiyagu06
   - thschue
+  - tiagoapolo
   - tjosepo
   - tomkerkhove
   - UtkarshSharma2612


### PR DESCRIPTION
Adds @tiagoapolo to the organisation. Tiago has joined the Flagsmith team primarily as a Front End Engineer and is looking to help with the JS SDK and Next.js.

@tiagoapolo this PR adds you to the Github org. If you approve or 👍 , we will merge it and you will get an invite. Being in the org comes with no obligation but allows us to contact you more easily and it's the first step on the [contributor ladder](https://github.com/open-feature/community/blob/main/CONTRIBUTOR_LADDER.md).