### PR TITLE
chore: add leohoare to org

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -97,6 +97,7 @@ members:
   - Kavindu-Dodan
   - kbychu
   - laliconfigcat
+  - leohoare
   - liran2000
   - lopitz
   - luizbon


### PR DESCRIPTION
@leohoare add support for async evaluation in the Python SDK.

- https://github.com/open-feature/python-sdk/pull/413

@leohoare this PR adds you to the OpenFeature org. If you approve or 👍 , we will merge it and you will get an invite. Being in the org comes with no obligation but allows us to contact you more easily and it's the first step on the [contributor ladder](https://github.com/open-feature/community/blob/main/CONTRIBUTOR_LADDER.md).