### PR TITLE
chore: remove members who didn't accept the invite

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -36,7 +36,6 @@ members:
   - agardnerIT
   - agentgonzo
   - ajhelsby
-  - ajwootto
   - alemrtv
   - alexandraoberaigner
   - AlexsJones
@@ -93,7 +92,6 @@ members:
   - juanparadox
   - justaugustus
   - justinabrahms
-  - kamil-nowosad
   - Kavindu-Dodan
   - kbychu
   - laliconfigcat


### PR DESCRIPTION
Removing members that failed to accept to invite. This will prevent the bot from repeatedly spamming them every few weeks.

https://github.com/orgs/open-feature/people/pending_invitations

> I left cupofcat since his invite is new and jrydberg since he's on the GC.