### PR TITLE
chore: add erenatas

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -71,6 +71,7 @@ members:
   - dominikhaska
   - dyladan
   - ejscunha
+  - erenatas
   - ericpattison
   - fabriziodemaria
   - faulkt


### PR DESCRIPTION
@erenatas recently contributed a [Rust flagd provider](https://github.com/open-feature/rust-sdk-contrib/pull/19). It was massive amount of work that showed an impressive level understand of OpenFeature and flagd.

Hey @erenatas! This PR invites you to join the OpenFeature org. Joining the org comes with no obligation, but allows us to ping you, and allows CI to run automatically on PRs from your forks. It's the first step on the [contributor ladder](https://github.com/open-feature/community/blob/main/CONTRIBUTOR_LADDER.md).

Please approve or 👍 this PR to signal your interest, and you'll receive an invite email.