### PR TITLE
chore: add gdegiorgio

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -77,6 +77,7 @@ members:
   - faulkt
   - federicobond
   - gagantrivedi
+  - gdegiorgio
   - gruebel
   - guidobrei
   - hairyhenderson


### PR DESCRIPTION
@gdegiorgio added an AWS SSM provider, and also fixed our package generation in js-contribs

https://github.com/open-feature/js-sdk-contrib/pull/1221

@gdegiorgio - this PR will add you to the org, which is the first step on the contributor ladder. Please approve or :+1: to signal your interest and you will get an email invite.