### PR TITLE
chore: promote alexandraoberaigner

### DIFF
--- a/config/open-feature/org/workgroup.yaml
+++ b/config/open-feature/org/workgroup.yaml
@@ -10,6 +10,7 @@ repos:
 approvers:
   - aepfli
   - agentgonzo
+  - alexandraoberaigner
   - AlexsJones
   - AloisReitbauer
   - bacherfl


### PR DESCRIPTION
@alexandraoberaigner has contributed:

- unix socket support for flagd sync: https://github.com/open-feature/flagd/pull/1560
- SSL support for flagd sync: https://github.com/open-feature/flagd/pull/1501
- various fixes to spec, doc and SDKs:
  - https://github.com/open-feature/java-sdk-contrib/pull/945
  - https://github.com/open-feature/spec/pull/299
  - more

And she is [speaking at KubeCon](https://kccnceu2025.sched.com/event/1tcxA/openfeature-update-from-the-maintainers-thomas-poignant-adevinta-lukas-reining-codecentric-ag-alexandra-oberaigner-dynatrace) about our latest SDK addition (tracking).

This PR promotes her to approver in the `org` work group (spec, community, etc) and the `cloud-native` workgroup (flagd, flagd-schema, etc).