### PR TITLE
chore: promote aepfli global maintainer

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -167,7 +167,8 @@ teams:
     members: []
 
   maintainers:
-    members: []
+    members:
+      - aepfli
 
   approvers:
     members: []


### PR DESCRIPTION
@aepfli has contributed a lot to this project:

- flagd features
- Java flagd fixes and features
- testing features, including the OpenFeature Junit test framework
- Python SDK and Python flagd
- The automation that runs in this repository and this PR uses

See: https://github.com/aepfli?org=open-feature

This PR promotes him to global maintainer in the project