### PR TITLE
chore: update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence
 
 # The config folder is used by Peribolos to configure org permissions
-/config/      @toddbaert @beeme1mr
+/config/      @open-feature/technical-steering-committee @open-feature/governance-board


### PR DESCRIPTION
The codeowners for the config repository have been strange, the tc and the governance board should be actually in charge of that
