### PR TITLE
Add Adeo organization as interested-party and adopter

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -4,6 +4,7 @@ A non-exhaustive, alphabetized list of organizations that have adopted OpenFeatu
 
 | Company                                           | Logo       | Notes |
 | ------------------------------------------------- | ---------- | :---: |
+| [Adeo](https://www.adeo.com/en/)                  |            |       |
 | [codecentric](https://www.codecentric.de/)        |            |       |
 | [Dynatrace](https://www.dynatrace.com)            |            |       |
 | [Ebay](https://www.ebay.com)                      |            |       |

--- a/interested-parties.md
+++ b/interested-parties.md
@@ -64,7 +64,7 @@ Everyone is also welcome to [participate](https://openfeature.dev/community/cont
 | Mitch Connors       | Google          | Istio, cobra                                                            | [therealmitchconnors](https://github.com/therealmitchconnors) | N/A                                               |
 | Moshe Beladev       | Torq            | Gebug, gTrace                                                           | [moshebe](https://github.com/moshebe)                         | N/A                                               |
 | Oleg Nenashev       | Dynatrace       | CDF, Jenkins, Keptn, FOSSi, API Neuchatel                               | [oleg-nenashev](https://github.com/oleg-nenashev)             | [oleg-nenashev](https://gitlab.com/oleg-nenashev) |
-| Paulo Piriquito     | N/A             |                                                                         | [paulopiriquito](https://github.com/paulopiriquito)           | N/A                                               |
+| Paulo Piriquito     | Adeo            |                                                                         | [paulopiriquito](https://github.com/paulopiriquito)           | N/A                                               |
 | Parth Suthar        | DevCycle        |                                                                         | [suthar26](https://github.com/suthar26)                       | N/A                                               |
 | Patricio Echague    | Split.io        |                                                                         | [patricioe](https://github.com/patricioe)                     | N/A                                               |
 | Pete Hodgson        | Independent     |                                                                         | [moredip](https://github.com/moredip)                         | N/A                                               |
@@ -92,6 +92,7 @@ List of companies, organizations, foundations and other groups that declared int
 
 | Organization    | Website link                                                           | Contact Email/Information                                                                     | Testimonial/case study link |
 | --------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | --------------------------- |
+| Adeo            | [adeo.com](https://www.adeo.com/en/)                                   | `paulopiriquito at github.com/adeo (paulo.piriquito@ext.leroymerlin.pt)`                      | N/A                         |
 | Alternative Payments | [alternativepayments.io](https://www.alternativepayments.io/)     | `fernando at alternativepayments.io`                                                          | N/A                         |
 | AWS AppConfig | [AWS AppConfig](https://docs.aws.amazon.com/appconfig/latest/userguide/what-is-appconfig.html) | `aws-appconfig-contact at amazon.com` | N/A |
 | Cisco           | [opensource.cisco.com](https://opensource.cisco.com/)                  | `augustus at cisco.com`                                                                       | N/A                         |


### PR DESCRIPTION
Adds Adeo as an interested party

## This PR

- adds [Adeo](https://github.com/adeo) as an interested party and adopter

### Notes

I'm adding to this list due to my involvement in the promotion and adoption of OpenFeature in the Adeo organization.

I'm currently leading internal interest groups within Adeo, and we are aiming for the adoption of OpenFeature as a standard. I also have been involved in local community talks to bring awareness to the benefits of OpenFeature (and feature toggling in general) as a practice to allow trunk-based development and continuous delivery.