### PR TITLE
promote Eren to rust approver

### DIFF
--- a/config/open-feature/sdk-rust/workgroup.yaml
+++ b/config/open-feature/sdk-rust/workgroup.yaml
@@ -3,7 +3,8 @@ repos:
   - rust-sdk
   - rust-sdk-contrib
 
-approvers: []
+approvers:
+  - erenatas
 
 maintainers:
   - AlexsJones


### PR DESCRIPTION
[Eren](https://github.com/erenatas) has actively contributed to the Rust SDK and the flagd provider. I'd like to nominate him to become an approver.