### PR TITLE
achieve inactive repo watchman

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -343,3 +343,4 @@ repos:
     private: true
   watchman:
     description: A Kubernetes admission controller driven by open-feature
+    archived: true


### PR DESCRIPTION
[Watchman](https://github.com/open-feature/watchman) was a prototype created for a previous KubeCon