### PR TITLE
chore: Add kylejuliandev to organization members list

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -97,6 +97,7 @@ members:
   - justinabrahms
   - Kavindu-Dodan
   - kbychu
+  - kylejuliandev
   - kriscoleman
   - laliconfigcat
   - leohoare


### PR DESCRIPTION
@kylejuliandev has been contributing to the OpenFeature dotnet SDK and contrib:

- https://github.com/search?q=is%3Apr%20author%3Akylejuliandev%20org%3Aopen-feature%20&type=pullrequests

He also created a blog post:
- https://blog.kylejulian.dev/posts/open-feature-intro/

@kylejuliandev, when merged, this PR will add you to the org (and send you an email invite). It comes with no obligation, but it's the first step on the https://github.com/open-feature/community/blob/main/CONTRIBUTOR_LADDER.md. Please approve or 👍 this PR to signal your interest!