### PR TITLE
chore: Add falghi to organization members list

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -74,6 +74,7 @@ members:
   - erenatas
   - ericpattison
   - fabriziodemaria
+  - falghi
   - faulkt
   - federicobond
   - gagantrivedi


### PR DESCRIPTION
@falghi added a Flipt provider for Ruby.

https://github.com/open-feature/ruby-sdk-contrib/pull/51

@falghi  - this PR will add you to the org, which is the first step on the contributor ladder. Please approve or 👍 to signal your interest and you will get an email invite.