### PR TITLE
Add jblacker to the org

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -90,6 +90,7 @@ members:
   - james-milligan
   - jamescarr
   - jarebudev
+  - jblacker
   - jbovet
   - jenshenneberg
   - josecolella


### PR DESCRIPTION
@jblacker recently contributed the multi-provider to the Go ecosystem based on @bbland1 initial implementation.

https://github.com/open-feature/go-sdk-contrib/pull/669

@jblacker, when merged, this PR will add you to the org (and send you an email invite). It comes with no obligation, but it's the first step on the [main/CONTRIBUTOR_LADDER.md](https://github.com/open-feature/community/blob/main/CONTRIBUTOR_LADDER.md). Please approve or 👍 this PR to signal your interest!