### PR TITLE
feat: Adding ofrep swift repo in the list for swift maintainers

### DIFF
--- a/config/open-feature/sdk-swift/workgroup.yaml
+++ b/config/open-feature/sdk-swift/workgroup.yaml
@@ -1,5 +1,6 @@
 repos:
   - swift-sdk
+  - ofrep-swift-client-provider
 
 approvers: []
 


### PR DESCRIPTION
## This PR
Adding https://github.com/open-feature/ofrep-swift-client-provider/ to the list of the repositories managed by the swift maintainer group.
