### PR TITLE
promote chrfwow to java maintainer

### DIFF
--- a/config/open-feature/sdk-java/workgroup.yaml
+++ b/config/open-feature/sdk-java/workgroup.yaml
@@ -8,7 +8,6 @@ approvers:
   - ajhelsby
   - thisthat
   - liran2000
-  - chrfwow
 
 maintainers:
   - aepfli
@@ -16,5 +15,6 @@ maintainers:
   - toddbaert
   - agentgonzo
   - kavindu-dodan
+  - chrfwow
 
 admins: []


### PR DESCRIPTION
Chrfwow has had a great impact on the Java SDK. His insights into concurrency and his level of detail help us thrive and move forward. His feedback on pull requests and issues (not only in the Java realm) has been highly valuable all the time. Hence I propose to promote him to maintainer of the Java realm.

- https://github.com/open-feature/java-sdk/pulls?q=is%3Apr+author%3Achrfwow
- https://github.com/open-feature/java-sdk-contrib/pulls?q=is%3Apr+author%3Achrfwow
- overall: https://github.com/search?q=org%3Aopen-feature+involves%3Achrfwow&type=issues

Full Disclosure: @chrfwow is working with me at Dynatrace, so I would love to hear feedback and insights from others regarding this promotion.

@chrfwow, if you approve of this promotion, please approve this pull request.



