### PR TITLE
chore: update governanve board to reflect current members

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -192,10 +192,11 @@ teams:
     members:
       - beeme1mr
       - AloisReitbauer
-      - AlexsJones
       - moredip
-      - justinabrahms
       - dabeeeenster
+      - jrydberg
+      - jonathannorris
+      - weyert
 
   Interested Parties:
     description: Group for members of https://github.com/openfeatureflags/governance/blob/main/interested-parties.md


### PR DESCRIPTION
The governance board has changed, and we adapted the org owners, but not the team members.



