### PR TITLE
chore: add tangenti, add cupofcat to flagd approvers

### DIFF
--- a/config/open-feature/flagd/workgroup.yaml
+++ b/config/open-feature/flagd/workgroup.yaml
@@ -9,13 +9,14 @@ approvers:
   - agardnerIT
   - alexandraoberaigner
   - beeme1mr
+  - cupofcat
   - craigpastro
   - justinabrahms
   - odubajDT
+  - tangenti
   - tcarrio
   - thisthat
   - thomaspoignant
- 
 
 maintainers:
   - AlexsJones


### PR DESCRIPTION
@tangenti and @cupofcat have both been contributing to the ongoing development of flagd, particularly the efforts to stabilize in preparation for a v1 release. They have contributed code, attended meetings, and understand the goals of the project. They are stewarding adoption efforts in their organization. 

This PR adds them to the `approvers` group for flagd.

https://github.com/cupofcat?tab=overview&org=open-feature

https://github.com/tangenti?tab=overview&org=open-feature

@tangenti @cupofcat please :+1:  or approve this PR to signal your interest in this role (read more about the [approver](https://github.com/open-feature/community/blob/main/CONTRIBUTOR_LADDER.md#approver) role here)