### PR TITLE
chore: move inactive users to emeritus

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -55,6 +55,7 @@ A workgroup consists of following roles:
 - approvers (triage permission)
 - maintainers (maintain permission)
 - admins (admin permission)
+- emeritus (no permissions, for historical reference only)
 
 Based on the definition above a `workgroup.yaml` has the following structure:
 

--- a/config/open-feature/cli/workgroup.yaml
+++ b/config/open-feature/cli/workgroup.yaml
@@ -1,6 +1,8 @@
 repos:
   - cli
 
+emeritus: []
+
 approvers: []
 
 maintainers:

--- a/config/open-feature/education/workgroup.yaml
+++ b/config/open-feature/education/workgroup.yaml
@@ -6,6 +6,8 @@ repos:
   - five-minutes-to-feature-flags
   - cloud-native-demo
 
+emeritus: []
+
 approvers:
   - justinabrahms
   - andrewdmaclean

--- a/config/open-feature/flagd/workgroup.yaml
+++ b/config/open-feature/flagd/workgroup.yaml
@@ -4,6 +4,11 @@ repos:
   - flagd-testbed
   - open-feature-operator
 
+emeritus:
+  - AlexsJones
+  - odubajDT
+  - skyerus
+
 approvers:
   - aepfli
   - agardnerIT
@@ -12,19 +17,16 @@ approvers:
   - cupofcat
   - craigpastro
   - justinabrahms
-  - odubajDT
   - tangenti
   - tcarrio
   - thisthat
   - thomaspoignant
 
 maintainers:
-  - AlexsJones
   - bacherfl
   - james-milligan
   - toddbaert
   - kavindu-dodan
-  - skyerus
   - lukas-reining
 
 admins: []

--- a/config/open-feature/org/workgroup.yaml
+++ b/config/open-feature/org/workgroup.yaml
@@ -6,6 +6,8 @@ repos:
   - spec
   - toc-proposal
 
+emeritus: []
+
 # keep alphabetical
 approvers:
   - aepfli

--- a/config/open-feature/sdk-dart/workgroup.yaml
+++ b/config/open-feature/sdk-dart/workgroup.yaml
@@ -1,6 +1,8 @@
 repos:
   - dart-server-sdk
 
+emeritus: []
+
 approvers: []
 
 maintainers:

--- a/config/open-feature/sdk-dotnet/workgroup.yaml
+++ b/config/open-feature/sdk-dotnet/workgroup.yaml
@@ -2,12 +2,14 @@ repos:
   - dotnet-sdk
   - dotnet-sdk-contrib
 
+emeritus:
+  - austindrenski
+  - cdonnellytx
+  - jenshenneberg
+  - bacherfl
+
 approvers:
   - arttonoyan
-  - bacherfl
-  - cdonnellytx
-  - austindrenski
-  - jenshenneberg
   - kylejuliandev
 
 maintainers:

--- a/config/open-feature/sdk-elixir/workgroup.yaml
+++ b/config/open-feature/sdk-elixir/workgroup.yaml
@@ -2,6 +2,8 @@ repos:
   - elixir-sdk
   - elixir-sdk-contrib
 
+emeritus: []
+
 approvers:
   - olunusib
 

--- a/config/open-feature/sdk-golang/workgroup.yaml
+++ b/config/open-feature/sdk-golang/workgroup.yaml
@@ -2,19 +2,21 @@ repos:
   - go-sdk
   - go-sdk-contrib
 
-approvers:
-  - bbland1
-  - beeme1mr
+emeritus:
   - agentgonzo
-  - thisthat
-
-maintainers:
   - AlexsJones
   - bacherfl
   - davejohnston
+  - skyerus
+
+approvers:
+  - bbland1
+  - beeme1mr
+  - thisthat
+
+maintainers:
   - james-milligan
   - Kavindu-Dodan
-  - skyerus
   - sahidvelji
   - thomaspoignant
   - toddbaert

--- a/config/open-feature/sdk-java/workgroup.yaml
+++ b/config/open-feature/sdk-java/workgroup.yaml
@@ -2,10 +2,13 @@ repos:
   - java-sdk
   - java-sdk-contrib
 
-approvers:
-  - thiyagu06
-  - thomaspoignant
+emeritus:
   - ajhelsby
+  - agentgonzo
+  - thiyagu06
+
+approvers:
+  - thomaspoignant
   - thisthat
   - liran2000
 
@@ -13,7 +16,6 @@ maintainers:
   - aepfli
   - justinabrahms
   - toddbaert
-  - agentgonzo
   - kavindu-dodan
   - chrfwow
 

--- a/config/open-feature/sdk-javascript/workgroup.yaml
+++ b/config/open-feature/sdk-javascript/workgroup.yaml
@@ -3,6 +3,8 @@ repos:
   - js-sdk-contrib
   - react-test-app
 
+emeritus: []
+
 approvers:
   - aepfli
   - weyert

--- a/config/open-feature/sdk-kotlin/workgroup.yaml
+++ b/config/open-feature/sdk-kotlin/workgroup.yaml
@@ -2,6 +2,8 @@ repos:
   - kotlin-sdk
   - kotlin-sdk-contrib
 
+emeritus: []
+
 approvers: 
   - bencehornak
   

--- a/config/open-feature/sdk-php/workgroup.yaml
+++ b/config/open-feature/sdk-php/workgroup.yaml
@@ -3,6 +3,8 @@ repos:
   - php-sdk
   - php-sdk-contrib
 
+emeritus: []
+
 approvers: []
 
 maintainers:

--- a/config/open-feature/sdk-python/workgroup.yaml
+++ b/config/open-feature/sdk-python/workgroup.yaml
@@ -2,16 +2,18 @@ repos:
   - python-sdk
   - python-sdk-contrib
 
+emeritus:
+  - ajhelsby
+  - hlipsig
+
 approvers: []
 
 maintainers:
   - federicobond
-  - hlipsig
   - dabeeeenster
   - mschoenlaub
   - tcarrio
   - matthewelwell
-  - ajhelsby
   - gruebel
 
 admins: []

--- a/config/open-feature/sdk-ruby/workgroup.yaml
+++ b/config/open-feature/sdk-ruby/workgroup.yaml
@@ -3,11 +3,13 @@ repos:
   - ruby-sdk
   - ruby-sdk-contrib
 
+emeritus:
+  - technicalpickles
+
 approvers:
   - maxveldink
 
 maintainers:
   - josecolella
-  - technicalpickles
 
 admins: []

--- a/config/open-feature/sdk-rust/workgroup.yaml
+++ b/config/open-feature/sdk-rust/workgroup.yaml
@@ -3,11 +3,13 @@ repos:
   - rust-sdk
   - rust-sdk-contrib
 
+emeritus:
+  - AlexsJones
+
 approvers:
   - erenatas
 
 maintainers:
-  - AlexsJones
   - sheepduke
 
 admins: []

--- a/config/open-feature/sdk-swift/workgroup.yaml
+++ b/config/open-feature/sdk-swift/workgroup.yaml
@@ -2,11 +2,13 @@ repos:
   - swift-sdk
   - ofrep-swift-client-provider
 
+emeritus:
+  - alina-v1
+  - Calibretto
+
 approvers: []
 
 maintainers:
-  - alina-v1
-  - Calibretto
   - fabriziodemaria
   - mfranberg
   - toddbaert

--- a/config/open-feature/spec-definition/workgroup.yaml
+++ b/config/open-feature/spec-definition/workgroup.yaml
@@ -1,5 +1,7 @@
 repos:
 
+emeritus: []
+
 approvers:
 
 maintainers:

--- a/config/open-feature/spec-evaluation/workgroup.yaml
+++ b/config/open-feature/spec-evaluation/workgroup.yaml
@@ -1,6 +1,8 @@
 repos:
   - protocol
 
+emeritus: []
+
 approvers:
 
 maintainers:

--- a/config/open-feature/tooling/workgroup.yaml
+++ b/config/open-feature/tooling/workgroup.yaml
@@ -1,6 +1,8 @@
 repos:
   - community-tooling
 
+emeritus: []
+
 approvers: []
 
 maintainers:


### PR DESCRIPTION
This PR moves any user who has had no activity within the org for 1 year into emeritus status (no permissions).

_**Please respond to this PR with a comment or a :-1: if you wish to keep your position**_. After 1 week, this PR will be merged.

As the `CONTRIBUTOR_LADDER` says:

> When a contributor returns to being more active, they may be promoted back to their previous position at the discretion of the current maintainers by opening a PR...

In other words, this is not a permanent change, and your position can be restored later, if desired; it's primarily housekeeping to reduce spam and remove un-needed access.

Regardless of your decision, thanks so much for your contributions and see you around! :pray: 

@agentgonzo
@ajhelsby
@AlexsJones
@alina-v1 
@arttonoyan
@bacherfl
@Calibretto
@cdonnellytx
@davejohnston
@hlipsig
@odubajDT
@skyerus
@technicalpickles
@thiyagu06