### PR TITLE
chore: add Brian as a dart maintainer

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -55,6 +55,7 @@ members:
   - bencehornak
   - benjiro
   - Billlynch
+  - brian-chebon
   - c4milo
   - Calibretto
   - cdonnellytx

--- a/config/open-feature/sdk-dart/workgroup.yaml
+++ b/config/open-feature/sdk-dart/workgroup.yaml
@@ -7,5 +7,6 @@ approvers: []
 
 maintainers:
   - ABC2015
+  - brian-chebon
 
 admins: []


### PR DESCRIPTION
## This PR

- adds @brian-chebon to the OpenFeature org
- adds @brian-chebon as a Dart maintainer

### Notes

@brian-chebon has been a key contributor to the [Dart SDK](https://github.com/open-feature/dart-server-sdk/). Please 👍 or approve this PR to signal your interest in this role (read more about the [approver](https://github.com/open-feature/community/blob/main/CONTRIBUTOR_LADDER.md#approver) role here)
