### PR TITLE
Add chrfwow as dotnet approver

### DIFF
--- a/config/open-feature/sdk-dotnet/workgroup.yaml
+++ b/config/open-feature/sdk-dotnet/workgroup.yaml
@@ -10,6 +10,7 @@ emeritus:
 
 approvers:
   - arttonoyan
+  - chrfwow
   - kylejuliandev
 
 maintainers:


### PR DESCRIPTION
This pull request adds a new approver to the OpenFeature .NET SDK workgroup configuration.

- Added `chrfwow` to the list of approvers in `config/open-feature/sdk-dotnet/workgroup.yaml`

## Notes

@chrfwow actively contributes to the dotnet-sdk by reviewing PRs and helping with his expertise.

@chrfwow, please approve this PR or +1 if you accept this nomination!