### PR TITLE
chore: invite alichka06 and 4gn3s to org

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -30,6 +30,7 @@ admins:
 # org member settings - keep alphabetical
 # add yourself here if you're interested in being an org member!
 members:
+  - 4gn3s
   - ABC2015
   - adams85
   - aepfli
@@ -39,6 +40,7 @@ members:
   - alemrtv
   - alexandraoberaigner
   - AlexsJones
+  - alichka06
   - alina-v1
   - alxckn
   - andrewdmaclean


### PR DESCRIPTION
As requested in slack: https://cloud-native.slack.com/archives/C09G371DQBT/p1761039893623429

They are working on the C++ SDK.

@alichka06 @4gn3s, please :+1:  this to confirm. Being in the org comes with not responsibilities, but gives you some limited access.