### PR TITLE
chore: add askpt and beeme1mr as MCP repo approvers

### DIFF
--- a/config/open-feature/mcp/workgroup.yaml
+++ b/config/open-feature/mcp/workgroup.yaml
@@ -1,6 +1,10 @@
 repos:
   - mcp
 
+approvers:
+  - askpt
+  - beeme1mr
+
 maintainers:
   - jonathannorris
 


### PR DESCRIPTION
Adding `askpt` and `beeme1mr` as approvers on the MCP repo, as they have been helping out and showing some interest in the MCP work.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
