### PR TITLE
chore: promote erka to go approver

### DIFF
--- a/config/open-feature/sdk-golang/workgroup.yaml
+++ b/config/open-feature/sdk-golang/workgroup.yaml
@@ -12,6 +12,7 @@ emeritus:
 approvers:
   - bbland1
   - beeme1mr
+  - erka
   - thisthat
 
 maintainers:


### PR DESCRIPTION
@erka has made code contibutions and done reviews across the go-sdk, go-sdk-contibs, and the specification.

https://github.com/erka?org=open-feature&year_list=1

This PR promotes them to [approver](https://github.com/open-feature/community/blob/main/CONTRIBUTOR_LADDER.md#approver).

@erka please :+1: or approve this PR if you understand the role and accept it. Thanks so much for your contributions so far.