### PR TITLE
Add c++ contrib repo

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -270,6 +270,10 @@ repos:
     description: C++ SDK for OpenFeature
     # Keep the repo private until the foundation is set up
     private: true
+  cpp-sdk-contrib:
+    description: OpenFeature Providers and Hooks for C++
+    # Keep the repo private until the foundation is set up
+    private: true
   contribfest-eu-24:
   dart-server-sdk:
   demo-repository:

--- a/config/open-feature/sdk-cpp/workgroup.yaml
+++ b/config/open-feature/sdk-cpp/workgroup.yaml
@@ -1,5 +1,6 @@
 repos:
   - cpp-sdk
+  - cpp-sdk-contrib
 
 maintainers:
   - NeaguGeorgiana23


### PR DESCRIPTION
## This PR

- adds a c++ contrib repo

### Notes

This repo will be internal just like the c++ repo until it's ready. The request for this repo was made on [Slack](https://cloud-native.slack.com/archives/C03J36ZP020/p1762178675871229).
