### PR TITLE
chore: add google team as cpp maintainers

### DIFF
--- a/config/open-feature/sdk-cpp/workgroup.yaml
+++ b/config/open-feature/sdk-cpp/workgroup.yaml
@@ -4,5 +4,8 @@ repos:
 
 maintainers:
   - NeaguGeorgiana23
+  - tangenti
+  - oxddr
+  - m-olko
 
 admins: []


### PR DESCRIPTION
https://cloud-native.slack.com/archives/C03J36ZP020/p1762178675871229