### PR TITLE
chore: add MattIPv4 to the org

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -119,6 +119,7 @@ members:
   - madhead
   - markphelps
   - matthewelwell
+  - MattIPv4
   - MaximFischuk
   - maxveldink
   - mfranberg


### PR DESCRIPTION
[Matt](https://github.com/MattIPv4) has [expressed interest in joining](https://cloud-native.slack.com/archives/C06E4DE6S07/p1763739804731189?thread_ts=1763664758.506709&cid=C06E4DE6S07) the OpenFeature Org. He has experience with the React SDK and has helped other on Slack. Joining doesn't come with any obligations but it makes it a bit easier to work on GitHub and is the first step in becoming a maintainer.