### PR TITLE
chore: Add 'carla-was-not-available' to org.yaml

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -60,6 +60,7 @@ members:
   - brian-chebon
   - c4milo
   - Calibretto
+  - carla-was-not-available
   - cdonnellytx
   - chrfwow
   - colebaileygit


### PR DESCRIPTION
@carla-was-not-available is actively contributing to the java landscape for multiple topics. 

- Issues: https://github.com/search?q=org%3Aopen-feature++involves%3Acarla-was-not-available&type=issues
- prs: https://github.com/search?q=org%3Aopen-feature+author%3Acarla-was-not-available&type=pullrequests

@carla-was-not-available, when merged, this PR will add you to the org (and send you an email invite). It comes with no obligation, but it's the first step on the [main/CONTRIBUTOR_LADDER.md](https://github.com/open-feature/community/blob/main/CONTRIBUTOR_LADDER.md). Please approve or 👍 this PR to signal your interest!