### PR TITLE
chore: promote erenatas to a Rust maintainer

### DIFF
--- a/config/open-feature/sdk-rust/workgroup.yaml
+++ b/config/open-feature/sdk-rust/workgroup.yaml
@@ -9,10 +9,10 @@ emeritus:
 triagers:
   - cupofcat
 
-approvers:
-  - erenatas
+approvers: []
 
 maintainers:
+  - erenatas
   - sheepduke
 
 admins: []


### PR DESCRIPTION
erenatas has been actively contributing to the Rust SDK and various providers. I'd like to promote him to a maintainer so that he can more effectively support the Rust SDK and contrib repos.
