### PR TITLE
fix: indicate that I am available re-election

### DIFF
--- a/Elections/2026/Candidates.md
+++ b/Elections/2026/Candidates.md
@@ -6,7 +6,7 @@ In February 2026 we will hold the election, with 4 positions being voted for. Th
 
 - [Johan Rydberg](https://github.com/jrydberg), Spotify (Up for re-election)
 - [Jonathan Norris](https://github.com/jonathannorris), DevCycle (Up for re-election)
-- [Weyert de Boer](https://github.com/weyert), FNZ (Up for re-election)
+- [Weyert de Boer](https://github.com/weyert), FNZ (Looking to continue board membership in 2026)
 - [Alois Reitbauer](https://github.com/AloisReitbauer), Dynatrace (Stepping down in 2026)
 
 ## Current Governance committee members (1 year term remaining)


### PR DESCRIPTION
## This PR
Updates the 2026 candidates page to mark myself as open for re-election in 2026

refs #512