### PR TITLE
Self-nominate Aaron Silverman for 2026 Governance Committee Election

### DIFF
--- a/Elections/2026/Candidates.md
+++ b/Elections/2026/Candidates.md
@@ -19,17 +19,6 @@ In February 2026 we will hold the election, with 4 positions being voted for. Th
 
 In alphabetical order:
 
-### Aaron Silverman
-- Company: Datadog
-- GitHub: [aarsilv](https://github.com/aarsilv)
-- Description: Engineering Manager for Feature Flags at Datadog following Datadog’s acquisition of Eppo. Leading the development of Datadog’s OpenFeature-first feature flagging platform. Passionate about experimentation and the intersection of feature flags, A/B testing, and canary rollouts. Excited to bring an experimentation-focused perspective to OpenFeature and help apply real-world learnings from Eppo’s customer base.
-
-<!--
-### Candidate Name
-- Company: Company Name
-- GitHub: [username](https://github.com/username)
-- Description: Description of candidate
--->
 <!--
 ### Candidate Name
 - Company: Company Name


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Add Aaron Silverman as one of the candidates for the 2026 Governance Committee election

### Related Issues
Related to #512 

### Notes
Followed [format guidelines](https://github.com/open-feature/community/blob/main/Elections/2026/Candidates.md?plain=1#L24)

### Follow-up Tasks
None

### How to test
N/A

