### PR TITLE
chore: add leoromanovsky to the organization list

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -112,6 +112,7 @@ members:
   - laliconfigcat
   - leohoare
   - leakonvalinka
+  - leoromanovsky
   - liran2000
   - lopitz
   - luizbon


### PR DESCRIPTION
@leoromanovsky (DataDog) has been helping with the Go SDK, and is now helping triage issues in Kotlin and Swift!

@leoromanovsky please :+1: or approve this PR and you will get an org-invite in your email when it's merged.