### PR TITLE
chore: make flagd-ofrep-cf-worker public

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -313,7 +313,6 @@ repos:
     homepage: https://buf.build/open-feature/flagd
   flagd-ofrep-cf-worker:
     description: Cloudflare Worker for OpenFeature Remote Evaluation Protocol using flagd
-    private: true
   go-sdk:
     description: Go SDK for OpenFeature
   go-sdk-contrib:


### PR DESCRIPTION
removes `private: true` from the `flagd-ofrep-cf-worker` repo config so the org tooling doesn't flip it back to private.