### PR TITLE
chore: Adding Nicklas to the TC

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -21,6 +21,7 @@ This is the current Technical Committee, per the Technical Committee Charter, in
 - [Lukas Reining](https://github.com/lukas-reining), [codecentric](https://www.codecentric.de/)
 - [Ryan Lamb](https://github.com/kinyoklion), [LaunchDarkly](https://github.com/launchdarkly)
 - [Todd Baert](https://github.com/toddbaert), [Dynatrace](https://github.com/Dynatrace)
+- [Nicklas Lundin](https://github.com/nicklasl), [Spotify](https://github.com/spotify/)
 
 ## Community Management
 

--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -26,6 +26,7 @@ admins:
   - lukas-reining
   - kinyoklion
   - toddbaert
+  - nicklasl
 
 # org member settings - keep alphabetical
 # add yourself here if you're interested in being an org member!
@@ -207,6 +208,7 @@ teams:
       - lukas-reining
       - kinyoklion
       - toddbaert
+      - nicklasl
 
   Governance Board:
     members:

--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -25,8 +25,8 @@ admins:
   # technical steering committee
   - lukas-reining
   - kinyoklion
-  - toddbaert
   - nicklasl
+  - toddbaert
 
 # org member settings - keep alphabetical
 # add yourself here if you're interested in being an org member!
@@ -207,8 +207,8 @@ teams:
     members:
       - lukas-reining
       - kinyoklion
-      - toddbaert
       - nicklasl
+      - toddbaert
 
   Governance Board:
     members:

--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -134,7 +134,6 @@ members:
   - mowies
   - mschoenlaub
   - NeaguGeorgiana23
-  - nicklasl
   - nickybondarenko
   - nikolasleblanc
   - odubajDT


### PR DESCRIPTION
## This PR
I am formally nominating Nicklas to join the OpenFeature Technical Committee. Nicklas has been a dedicated contributor to the OpenFeature ecosystem for several years, specifically driving the development and refinement of our mobile SDKs.

Beyond his direct contributions to the project, Nicklas brings a wealth of experience from his work on Confidence by Spotify. His deep understanding of enterprise-scale feature flagging, experimentation and cross-platform SDK architecture will be an invaluable asset to the TC as we continue to evolve OpenFeature.

@nicklasl,  please add a 👍 to this issue if you accept the nomination.
