### PR TITLE
chore: add JamieSinn to the organization members list

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -97,6 +97,7 @@ members:
   - jakedoublev
   - james-milligan
   - jamescarr
+  - JamieSinn
   - jarebudev
   - jblacker
   - jbovet


### PR DESCRIPTION
@JamieSinn has been contributing across the org, including spec tooling (open-feature/spec#388, open-feature/spec#389), a benchmarking testbed for flagd (#530), and fixes in js-sdk-contrib (open-feature/js-sdk-contrib#1559).

https://github.com/search?q=org%3Aopen-feature+involves%3AJamieSinn&type=pullrequests
https://github.com/search?q=org%3Aopen-feature+involves%3AJamieSinn&type=issues

@JamieSinn please :+1: or approve this PR to signal your interest in joining the org, and you'll get an invite in your email.