### PR TITLE
chore: Remove Andrew MacLean from community maintainers 

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -27,7 +27,6 @@ This is the current Technical Committee, per the Technical Committee Charter, in
 
 These are community maintainers responsible for cross-functional project communications, events, and other functions as needed.
 
-- [Andrew MacLean](https://github.com/andrewdmaclean) DevCycle
 - [David Hirsch](https://github.com/DavidPHirsch) Dynatrace
 
 ### Project roles


### PR DESCRIPTION

## This PR
Removed Andrew MacLean from the community members list. 

Andrew is no longer affiliated with DevCycle. I haven't removed from any access/permissions as that's more in line with TSC/GC.

