### PR TITLE
ci: build peribolos from upstream, add retry

### DIFF
--- a/.github/workflows/peribolos.yaml
+++ b/.github/workflows/peribolos.yaml
@@ -35,12 +35,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    # Gate the job by environment based on event:
-    # - PR runs use `peribolos-verify` (read-only token, any branch).
-    # - Push / cron runs use `peribolos-apply` (admin:org token, main only).
+    # Gate the job by environment based on ref:
+    # - Runs on main use `peribolos-apply` (admin:org token, main only).
+    # - All other refs (PRs) use `peribolos-verify` (read-only token, any branch).
     # The secret name (PERIBOLOS_GH_TOKEN) is the same in both environments;
     # GitHub resolves it to whichever value the gating environment holds.
-    environment: ${{ github.event_name == 'pull_request' && 'peribolos-verify' || 'peribolos-apply' }}
+    environment: ${{ github.ref == 'refs/heads/main' && 'peribolos-apply' || 'peribolos-verify' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/peribolos.yaml
+++ b/.github/workflows/peribolos.yaml
@@ -9,8 +9,20 @@ on:
     paths:
       - 'tools/**'
       - 'config/**'
+      - '.github/workflows/peribolos.yaml'
   schedule:
     - cron: "0 0 * * *"
+
+# This workflow uses the admin:org-scoped PERIBOLOS_GH_TOKEN secret. Keep
+# permissions minimal: we never need the default GITHUB_TOKEN for anything.
+permissions:
+  contents: read
+
+# Avoid concurrent runs that could fight over org state. Don't cancel a
+# running apply just because a new push arrived; let it finish.
+concurrency:
+  group: peribolos
+  cancel-in-progress: false
 
 env:
   PERIBOLOS_ARGS: "--fix-org --fix-org-members --fix-repos --fix-team-members --fix-teams --fix-team-repos --maximum-removal-delta=1 --github-allowed-burst=300 --github-hourly-tokens=1000 --allow-repo-archival"
@@ -22,38 +34,45 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Generating Peribolos configuration
         uses: docker://ghcr.io/open-feature/community-tooling:v0
 
       - name: Preparing credentials
-        run: echo ${{ secrets.PERIBOLOS_GH_TOKEN }} >> github-token # a secret with the user token to be used for execution
+        env:
+          PERIBOLOS_GH_TOKEN: ${{ secrets.PERIBOLOS_GH_TOKEN }}
+        run: |
+          umask 077
+          printf '%s' "$PERIBOLOS_GH_TOKEN" > "$RUNNER_TEMP/github-token"
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25'
 
-      - name: Cache Go modules and build
-        uses: actions/cache@v4
+      - name: Cache Go modules
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: peribolos-${{ env.PROW_PERIBOLOS_REF }}-${{ runner.os }}
+          # Only cache modules, not built binaries. Reduces blast radius if the
+          # cache namespace is ever poisoned by a malicious PR run.
+          path: ~/go/pkg/mod
+          key: peribolos-mod-${{ env.PROW_PERIBOLOS_REF }}-${{ runner.os }}
 
       - name: Install peribolos
-        run: go install sigs.k8s.io/prow/cmd/peribolos@${{ env.PROW_PERIBOLOS_REF }}
+        run: go install "sigs.k8s.io/prow/cmd/peribolos@${PROW_PERIBOLOS_REF}"
 
       - name: Run Peribolos Configuration Verification
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           for i in 1 2 3; do
             echo "::group::peribolos verify attempt $i/3"
-            if peribolos $PERIBOLOS_ARGS --github-token-path github-token --config-path config/peribolos.yaml; then
+            if peribolos $PERIBOLOS_ARGS --github-token-path "$RUNNER_TEMP/github-token" --config-path config/peribolos.yaml; then
               echo "::endgroup::"
               exit 0
             fi
@@ -68,7 +87,7 @@ jobs:
         run: |
           for i in 1 2 3; do
             echo "::group::peribolos apply attempt $i/3"
-            if peribolos $PERIBOLOS_ARGS --github-token-path github-token --config-path config/peribolos.yaml --confirm; then
+            if peribolos $PERIBOLOS_ARGS --github-token-path "$RUNNER_TEMP/github-token" --config-path config/peribolos.yaml --confirm; then
               echo "::endgroup::"
               exit 0
             fi
@@ -77,3 +96,7 @@ jobs:
           done
           echo "peribolos apply failed after 3 attempts"
           exit 1
+
+      - name: Clean up credentials
+        if: always()
+        run: rm -f "$RUNNER_TEMP/github-token"

--- a/.github/workflows/peribolos.yaml
+++ b/.github/workflows/peribolos.yaml
@@ -53,9 +53,7 @@ jobs:
       - name: Preparing credentials
         env:
           PERIBOLOS_GH_TOKEN: ${{ secrets.PERIBOLOS_GH_TOKEN }}
-        run: |
-          umask 077
-          printf '%s' "$PERIBOLOS_GH_TOKEN" > "$RUNNER_TEMP/github-token"
+        run: echo "$PERIBOLOS_GH_TOKEN" > "$RUNNER_TEMP/github-token"
 
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0

--- a/.github/workflows/peribolos.yaml
+++ b/.github/workflows/peribolos.yaml
@@ -35,6 +35,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # Gate the job by environment based on event:
+    # - PR runs use `peribolos-verify` (read-only token, any branch).
+    # - Push / cron runs use `peribolos-apply` (admin:org token, main only).
+    # The secret name (PERIBOLOS_GH_TOKEN) is the same in both environments;
+    # GitHub resolves it to whichever value the gating environment holds.
+    environment: ${{ github.event_name == 'pull_request' && 'peribolos-verify' || 'peribolos-apply' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -55,14 +61,6 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25'
-
-      - name: Cache Go modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          # Only cache modules, not built binaries. Reduces blast radius if the
-          # cache namespace is ever poisoned by a malicious PR run.
-          path: ~/go/pkg/mod
-          key: peribolos-mod-${{ env.PROW_PERIBOLOS_REF }}-${{ runner.os }}
 
       - name: Install peribolos
         run: go install "sigs.k8s.io/prow/cmd/peribolos@${PROW_PERIBOLOS_REF}"

--- a/.github/workflows/peribolos.yaml
+++ b/.github/workflows/peribolos.yaml
@@ -14,6 +14,10 @@ on:
 
 env:
   PERIBOLOS_ARGS: "--fix-org --fix-org-members --fix-repos --fix-team-members --fix-teams --fix-team-repos --maximum-removal-delta=1 --github-allowed-burst=300 --github-hourly-tokens=1000 --allow-repo-archival"
+  # Pinned commit on kubernetes-sigs/prow main (no tagged releases exist).
+  # Bump by editing this line; the cache key includes the SHA so a new build is
+  # triggered automatically. See https://github.com/kubernetes-sigs/prow.
+  PROW_PERIBOLOS_REF: "2b5fea27a177c767160452ba75dba978a88d8d63"
 
 jobs:
   build:
@@ -28,14 +32,48 @@ jobs:
       - name: Preparing credentials
         run: echo ${{ secrets.PERIBOLOS_GH_TOKEN }} >> github-token # a secret with the user token to be used for execution
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      - name: Cache Go modules and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: peribolos-${{ env.PROW_PERIBOLOS_REF }}-${{ runner.os }}
+
+      - name: Install peribolos
+        run: go install sigs.k8s.io/prow/cmd/peribolos@${{ env.PROW_PERIBOLOS_REF }}
+
       - name: Run Peribolos Configuration Verification
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: docker://ghcr.io/dynatrace-innovationlab/peribolos:v0
-        with:
-          args: ${{ env.PERIBOLOS_ARGS }} --github-token-path github-token --config-path config/peribolos.yaml
+        run: |
+          for i in 1 2 3; do
+            echo "::group::peribolos verify attempt $i/3"
+            if peribolos $PERIBOLOS_ARGS --github-token-path github-token --config-path config/peribolos.yaml; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            echo "attempt $i/3 failed"
+          done
+          echo "peribolos verify failed after 3 attempts"
+          exit 1
 
       - name: Apply Peribolos Configuration
         if: github.event_name != 'pull_request'
-        uses: docker://ghcr.io/dynatrace-innovationlab/peribolos:v0
-        with:
-          args: ${{ env.PERIBOLOS_ARGS }} --github-token-path github-token --config-path config/peribolos.yaml --confirm
+        run: |
+          for i in 1 2 3; do
+            echo "::group::peribolos apply attempt $i/3"
+            if peribolos $PERIBOLOS_ARGS --github-token-path github-token --config-path config/peribolos.yaml --confirm; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            echo "attempt $i/3 failed"
+          done
+          echo "peribolos apply failed after 3 attempts"
+          exit 1

--- a/config/README.md
+++ b/config/README.md
@@ -1,7 +1,5 @@
 # Community Configuration
 
-<!-- temp: trigger peribolos workflow on PR #555 to validate runtime-build + retry; remove before merge -->
-
 As handling permissions, assignments, etc. gets more and more complicated, the bigger a community gets,
 we decided to opt-in for a GitOps approach for community management.
 

--- a/config/README.md
+++ b/config/README.md
@@ -1,5 +1,7 @@
 # Community Configuration
 
+<!-- temp: trigger peribolos workflow on PR #555 to validate runtime-build + retry; remove before merge -->
+
 As handling permissions, assignments, etc. gets more and more complicated, the bigger a community gets,
 we decided to opt-in for a GitOps approach for community management.
 


### PR DESCRIPTION
The peribolos workflow has been failing daily/intermittently with `401 Bad credentials` responses from GitHub on otherwise valid API calls. The token is healthy; the errors are might just be GitHub-side flakiness that the prow github client doesn't retry...

This PR replaces the abandoned `ghcr.io/dynatrace-innovationlab/peribolos:v0` image (this was only used in 2022 before this prow code was separated) with a runtime build of peribolos from `kubernetes-sigs/prow` pinned to a specific commit SHA, wraps the verify and apply steps in a 3-attempt retry loop, and hardens the workflow (minimal permissions, SHA-pinned actions, timeout, concurrency group, token written outside the workspace). The job is also gated by environment so PR runs use a read-only token and only `main` can access the admin:org token.