### PR TITLE
chore: archive ofep repo

### DIFF
--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -346,6 +346,7 @@ repos:
     description: A focal point for OpenFeature research, proposals and requests
       for comments
     has_projects: false
+    archived: true
   open-feature-operator:
     description: A Kubernetes feature flag operator
   open-feature.github.io:

--- a/config/open-feature/org/workgroup.yaml
+++ b/config/open-feature/org/workgroup.yaml
@@ -1,5 +1,4 @@
 repos:
-  - ofep
   - community
   - community-tooling
   - .github


### PR DESCRIPTION
Archives `open-feature/ofep` via peribolos and removes it from the org workgroup's repos list. The workflow already runs with `--allow-repo-archival`, so this will take effect on the next apply.