### PR TITLE
fix: use markdown image links in branding guidelines

### DIFF
--- a/branding-guidelines.md
+++ b/branding-guidelines.md
@@ -30,7 +30,7 @@ Use this icon variant for places where you need support for both dark and light 
 
 | SVG | PNG |
 | --- | --- |
-| <img src="./assets/logo/icon/dual/openfeature-icon-dual.svg" alt="OpenFeature dual-mode SVG icon" width="128" /> | <img src="./assets/logo/icon/dual/openfeature-icon-dual.png" alt="OpenFeature dual-mode PNG icon" width="128" /> |
+| ![OpenFeature dual-mode SVG icon](./assets/logo/icon/dual/openfeature-icon-dual.svg) | ![OpenFeature dual-mode PNG icon](./assets/logo/icon/dual/openfeature-icon-dual.png) |
 
 ## Colors
 


### PR DESCRIPTION
## Summary

Replace raw HTML image tags with Markdown image links in `branding-guidelines.md`.

The original `<img>` tags were added in community PR [#552](https://github.com/open-feature/community/pull/552), merged on June 25, 2026, in commit `d857bd7`.

This allows Docusaurus to resolve and bundle the dual-mode logo assets correctly when the community repository is used as a submodule by `openfeature.dev`.

Related: https://github.com/open-feature/openfeature.dev/pull/1442