### PR TITLE
chore: promote erka to go-sdk maintainer and flagd approver

### DIFF
--- a/config/open-feature/flagd/workgroup.yaml
+++ b/config/open-feature/flagd/workgroup.yaml
@@ -23,6 +23,7 @@ approvers:
   - beeme1mr
   - cupofcat
   - craigpastro
+  - erka
   - justinabrahms
   - tangenti
   - tcarrio

--- a/config/open-feature/sdk-golang/workgroup.yaml
+++ b/config/open-feature/sdk-golang/workgroup.yaml
@@ -16,10 +16,10 @@ triagers:
 approvers:
   - bbland1
   - beeme1mr
-  - erka
   - thisthat
 
 maintainers:
+  - erka
   - james-milligan
   - sahidvelji
   - thomaspoignant


### PR DESCRIPTION
Nominating @erka for **go-sdk maintainer** (promoting from approver) and **flagd approver**. @erka has contributed significantly ([PRs](https://github.com/search?q=org%3Aopen-feature+author%3Aerka&type=pullrequests) and [issues](https://github.com/search?q=org%3Aopen-feature+author%3Aerka&type=issues)) to the go-sdk, go-sdk-contrib, flagd, and the specification, and has been a consistent, high-quality reviewer.

@erka: please :+1: or approve this PR to signal your interest in these roles.
