### PR TITLE
chore: nominate aepfli to the technical committee

### DIFF
--- a/community-members.md
+++ b/community-members.md
@@ -20,6 +20,7 @@ This is the current Technical Committee, per the Technical Committee Charter, in
 
 - [Lukas Reining](https://github.com/lukas-reining), [codecentric](https://www.codecentric.de/)
 - [Ryan Lamb](https://github.com/kinyoklion), [LaunchDarkly](https://github.com/launchdarkly)
+- [Simon Schrottner](https://github.com/aepfli)
 - [Todd Baert](https://github.com/toddbaert), [Dynatrace](https://github.com/Dynatrace)
 - [Nicklas Lundin](https://github.com/nicklasl), [Spotify](https://github.com/spotify/)
 

--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -35,7 +35,6 @@ members:
   - 4gn3s
   - ABC2015
   - adams85
-  - aepfli
   - agardnerIT
   - agentgonzo
   - ajhelsby

--- a/config/open-feature/org.yaml
+++ b/config/open-feature/org.yaml
@@ -23,6 +23,7 @@ admins:
 
 
   # technical steering committee
+  - aepfli
   - lukas-reining
   - kinyoklion
   - nicklasl
@@ -206,6 +207,7 @@ teams:
 
   Technical Steering Committee:
     members:
+      - aepfli
       - lukas-reining
       - kinyoklion
       - nicklasl


### PR DESCRIPTION
Nominating @aepfli (Simon Schrottner) for the **OpenFeature Technical Committee**. @aepfli has contributed significantly ([PRs](https://github.com/search?q=org%3Aopen-feature+author%3Aaepfli&type=pullrequests) and [issues](https://github.com/search?q=org%3Aopen-feature+author%3Aaepfli&type=issues)) across flagd, the SDKs, and org-wide tooling, and has been an active technical leader in the project.

Per the Technical Committee Charter, TC members are elected by a super-majority vote of the existing TC (with a GC veto); consider this the nomination.

@aepfli: please :+1: or approve this PR to signal your interest in this role.
